### PR TITLE
Use Elasticsearch container from data-explorer repo

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -31,7 +31,6 @@ if you haven't done so already.
     ```
     docker-compose up -d elasticsearch
     ```
-    In `docker-compose.yml`, change ELASTICSEARCH_URL to `localhost:9200`.
 * Run the indexer.
   * If using default dataset: `docker-compose up --build indexer`
   * If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build indexer`

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -22,15 +22,19 @@ if you haven't done so already.
 * If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
 * Run Elasticsearch.
   * If you intend to run the Data Explorer UI from the [data-explorer repo](https://github.com/DataBiosphere/data-explorer/)
-    after this, run inside the data-explorer repo: `docker-compose up --build elasticsearch'
+    after this, run inside the data-explorer repo:
+    ```
+    docker-compose up --build elasticsearch
+    ```
   * If you do not intend to run the Data Explorer UI after this, and just want
     to inspect the index in Elasticsearch, run:
     ```
     docker run -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
     ```
     In `docker-compose.yml`, change ELASTICSEARCH_URL to `localhost:9200`.
-* If using default dataset: `docker-compose up --build`
-  If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build`
+* Run the indexer.
+  * If using default dataset: `docker-compose up --build`
+  * If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build`
 * View Elasticsearch index at
  `http://localhost:9200/platinum_genomes/_search?pretty=true`. If using your
  own dataset, change `platinum_genomes` to your dataset name.

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -24,17 +24,17 @@ if you haven't done so already.
   * If you intend to run the Data Explorer UI from the [data-explorer repo](https://github.com/DataBiosphere/data-explorer/)
     after this, run inside the data-explorer repo:
     ```
-    docker-compose up --build elasticsearch
+    docker-compose up -d elasticsearch
     ```
   * If you do not intend to run the Data Explorer UI after this, and just want
-    to inspect the index in Elasticsearch, run:
+    to inspect the index in Elasticsearch, run inside this repo:
     ```
-    docker run -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
+    docker-compose up -d elasticsearch
     ```
     In `docker-compose.yml`, change ELASTICSEARCH_URL to `localhost:9200`.
 * Run the indexer.
-  * If using default dataset: `docker-compose up --build`
-  * If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build`
+  * If using default dataset: `docker-compose up --build indexer`
+  * If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build indexer`
 * View Elasticsearch index at
  `http://localhost:9200/platinum_genomes/_search?pretty=true`. If using your
  own dataset, change `platinum_genomes` to your dataset name.

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -2,24 +2,34 @@
 
 ### Quickstart
 
-Index a BigQuery table into an Elasticsearch container on your local machine.
+Index a [default public BigQuery table](https://bigquery.cloud.google.com/table/google.com:biggene:platinum_genomes.sample_info)
+into an Elasticsearch container on your local machine.
 
-* If you want to use a [sample public dataset](https://bigquery.cloud.google.com/table/google.com:biggene:platinum_genomes.sample_info):
-  * [Install bq](https://cloud.google.com/bigquery/docs/bq-command-line-tool#installation)
+* [Install bq](https://cloud.google.com/bigquery/docs/bq-command-line-tool#installation)
 if you haven't done so already.
-  * Copy dataset to your project.
-    ```
-    bq --project_id MY_GOOGLE_CLOUD_PROJECT mk platinum_genomes
-    bq --project_id MY_GOOGLE_CLOUD_PROJECT cp google.com:biggene:platinum_genomes.sample_info  MY_GOOGLE_CLOUD_PROJECT:platinum_genomes.sample_info
-    ```
-  * Change project ids in `dataset_config/platinum_genomes/facet_fields.csv`.
-* If you want to use your own dataset:
-  * Create a config directory for your dataset, e.g. `dataset_config/amp_pd`.
-  Copy `dataset_config/template/*` to this directory.
+* Copy table to your project.
+  ```
+  bq --project_id MY_GOOGLE_CLOUD_PROJECT mk platinum_genomes
+  bq --project_id MY_GOOGLE_CLOUD_PROJECT cp google.com:biggene:platinum_genomes.sample_info  MY_GOOGLE_CLOUD_PROJECT:platinum_genomes.sample_info
+  ```
+* Change project ids in `dataset_config/platinum_genomes/facet_fields.csv`.
+* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
+* `docker-compose up --build`
+* View Elasticsearch index:
+ `http://localhost:9200/platinum_genomes/_search?pretty=true`.
+
+If you want to run the Data Explorer UI on this dataset, follow the instructions
+below. Note that you will have to reindex the data into an Elasticsearch
+container from the [data-explorer repo](https://github.com/DataBiosphere/data-explorer/).
+
+### Index a custom dataset locally
+
+* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
+* Setup config files.
+  * Create `dataset_config/<my_dataset>`. Copy `dataset_config/template/*` to this directory.
   * Edit config files; instructions are in the files. Read
   [Overview](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery#overview)
   for some background information.
-* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
 * Run Elasticsearch.
   * If you intend to run the Data Explorer UI from the [data-explorer repo](https://github.com/DataBiosphere/data-explorer/)
     after this, run inside the data-explorer repo:
@@ -31,15 +41,11 @@ if you haven't done so already.
     ```
     docker-compose up -d elasticsearch
     ```
-* Run the indexer.
-  * If using default dataset: `docker-compose up --build indexer`
-  * If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build indexer`
-* View Elasticsearch index at
- `http://localhost:9200/platinum_genomes/_search?pretty=true`. If using your
- own dataset, change `platinum_genomes` to your dataset name.
-
-If using your own dataset: Now that your dataset is indexed, follow
-https://github.com/DataBiosphere/data-explorer to bring up a Data explorer UI.
+* Run the indexer:
+`DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build indexer`
+* List Elasticsearch indices: `http://localhost:9200/_cat/indices?v`  
+  View Elasticsearch index: `http://localhost:9200/MY_DATASET/_search?pretty=true`.
+* If you want to see local Data Explorer UI, [follow these instructions](https://github.com/DataBiosphere/data-explorer/blob/5441559c57ab7a2e0813e8e4fe7e19a9394f1bdf/README.md#run-local-data-explorer-with-a-specific-dataset).
 
 ### Overview
 

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -20,6 +20,15 @@ if you haven't done so already.
   [Overview](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery#overview)
   for some background information.
 * If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
+* Run Elasticsearch.
+  * If you intend to run the Data Explorer UI from the [data-explorer repo](https://github.com/DataBiosphere/data-explorer/)
+    after this, run inside the data-explorer repo: `docker-compose up --build elasticsearch'
+  * If you do not intend to run the Data Explorer UI after this, and just want
+    to inspect the index in Elasticsearch, run:
+    ```
+    docker run -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
+    ```
+    In `docker-compose.yml`, change ELASTICSEARCH_URL to `localhost:9200`.
 * If using default dataset: `docker-compose up --build`
   If using custom dataset: `DATASET_CONFIG_DIR=dataset_config/MY_DATASET docker-compose up --build`
 * View Elasticsearch index at

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -12,11 +12,11 @@ if you haven't done so already.
   bq --project_id MY_GOOGLE_CLOUD_PROJECT mk platinum_genomes
   bq --project_id MY_GOOGLE_CLOUD_PROJECT cp google.com:biggene:platinum_genomes.sample_info  MY_GOOGLE_CLOUD_PROJECT:platinum_genomes.sample_info
   ```
-* Change project ids in `dataset_config/platinum_genomes/facet_fields.csv`.
-* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
+* Change project ids in `dataset_config/platinum_genomes/facet_fields.csv`
+* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`
 * `docker-compose up --build`
 * View Elasticsearch index:
- `http://localhost:9200/platinum_genomes/_search?pretty=true`.
+ `http://localhost:9200/platinum_genomes/_search?pretty=true`
 
 If you want to run the Data Explorer UI on this dataset, follow the instructions
 below. Note that you will have to reindex the data into an Elasticsearch
@@ -24,7 +24,7 @@ container from the [data-explorer repo](https://github.com/DataBiosphere/data-ex
 
 ### Index a custom dataset locally
 
-* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`.
+* If `~/.config/gcloud/application_default_credentials.json` doesn't exist, create it by running `gcloud auth application-default login`
 * Setup config files.
   * Create `dataset_config/<my_dataset>`. Copy `dataset_config/template/*` to this directory.
   * Edit config files; instructions are in the files. Read
@@ -44,7 +44,7 @@ container from the [data-explorer repo](https://github.com/DataBiosphere/data-ex
 * Run the indexer:
 `DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build indexer`
 * List Elasticsearch indices: `http://localhost:9200/_cat/indices?v`  
-  View Elasticsearch index: `http://localhost:9200/MY_DATASET/_search?pretty=true`.
+  View Elasticsearch index: `http://localhost:9200/MY_DATASET/_search?pretty=true`
 * If you want to see local Data Explorer UI, [follow these instructions](https://github.com/DataBiosphere/data-explorer/blob/5441559c57ab7a2e0813e8e4fe7e19a9394f1bdf/README.md#run-local-data-explorer-with-a-specific-dataset).
 
 ### Overview

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -1,5 +1,9 @@
 version: '3'
 services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
+    ports:
+      - 127.0.0.1:9200:9200
   indexer:
     build:
       context: .
@@ -16,6 +20,6 @@ services:
 networks:
   default:
     external:
-      # Use network from data-explorer repo, so dataset will be indexed into
-      # data-explorer's Elasticsearch container.
+      # This is only needed for indexing data into an Elasticsearch container
+      # from the data-explorer repo. Use the network from that repo.
       name: dataexplorer_default

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -1,9 +1,5 @@
 version: '3'
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.2
-    ports:
-      - 127.0.0.1:9200:9200
   indexer:
     build:
       context: .
@@ -17,3 +13,9 @@ services:
       # GKE runs, which are authenticated as service account. (The service
       # account credentials are automatically picked up.)
       - ~/.config/gcloud:/root/.config/gcloud
+networks:
+  default:
+    external:
+      # Use network from data-explorer repo, so dataset will be indexed into
+      # data-explorer's Elasticsearch container.
+      name: dataexplorer_default


### PR DESCRIPTION
I realized #13 broke using running indexer for different datasets for local deployment.

Before #13:
* Elasticsearch started by docker-compose in data-explorer repo
* indexer.py runs against localhost:9200. 

After #13:
* indexer indexes into Elasticsearch container from this repo's `docker-compose.yml`.

After this PR:
* Elasticsearch started by docker-compose in data-explorer repo
* indexer indexes into Elasticsearch container from *data-explorer repo*