### PR TITLE
Fix docker-compose up

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -26,6 +26,14 @@ logger = logging.getLogger('indexer.bigquery')
 ES_TIMEOUT_SEC = 20
 
 
+# Copied from https://stackoverflow.com/a/45392259
+def environ_or_required(key):
+    if os.environ.get(key):
+        return {'default': os.environ.get(key)}
+    else:
+        return {'required': True}
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -43,8 +51,7 @@ def parse_args():
         type=str,
         help=
         'The project that will be billed for querying BigQuery tables. The account running this script must have bigquery.jobs.create permission on this project.',
-        default=os.environ.get('BILLING_PROJECT_ID'),
-        required=True)
+        **environ_or_required('BILLING_PROJECT_ID'))
     return parser.parse_args()
 
 


### PR DESCRIPTION
The `docker-compose up` command from #22 doesn't actually work. Before this PR:
```
BILLING_PROJECT_ID=google.com:api-project-360728701457 docker-compose up --build

indexer_1        | usage: indexer.py [-h] [--elasticsearch_url ELASTICSEARCH_URL]
indexer_1        |                   [--dataset_config_dir DATASET_CONFIG_DIR]
indexer_1        |                   --billing_project_id BILLING_PROJECT_ID
indexer_1        | indexer.py: error: argument --billing_project_id is required
bigquery_indexer_1 exited with code 2
```
[See here](https://stackoverflow.com/questions/10551117/setting-options-from-environment-variables-when-using-argparse) for an explanation and solution. After this PR, `docker-compose up` works as expected.