### PR TITLE
Don't delete index in beginning of indexer.py

### DIFF
--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -56,6 +56,12 @@
     ```
 
 * Run indexer on GKE
+  * We recommend you delete the index, to start from a clean slate.
+    ```
+    kubectl get svc,pods
+    kubectl exec -it ES_CLIENT_POD -- /bin/bash
+    curl -XDELETE EXTERNAL_IP:9200/MY_DATASET
+    ```
   * Make sure the config files in `bigquery/dataset_config/MY_DATASET` are
   filled out.
   If you don't yet have config files for your dataset, follow the [instructions for local deployment](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery#index-a-custom-dataset-locally)

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -122,7 +122,8 @@ def main():
     dataset_config = indexer_util.open_and_return_json(json_path)
     index_name = indexer_util.convert_to_index_name(dataset_config['name'])
 
-    es = indexer_util.maybe_create_elasticsearch_index(args.elasticsearch_url, index_name)
+    es = indexer_util.maybe_create_elasticsearch_index(args.elasticsearch_url,
+                                                       index_name)
 
     primary_key = dataset_config['primary_key']
     f = open(os.path.join(args.dataset_config_dir, 'facet_fields.csv'))

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -122,7 +122,7 @@ def main():
     dataset_config = indexer_util.open_and_return_json(json_path)
     index_name = indexer_util.convert_to_index_name(dataset_config['name'])
 
-    es = indexer_util.init_elasticsearch(args.elasticsearch_url, index_name)
+    es = indexer_util.maybe_create_elasticsearch_index(args.elasticsearch_url, index_name)
 
     primary_key = dataset_config['primary_key']
     f = open(os.path.join(args.dataset_config_dir, 'facet_fields.csv'))

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -92,8 +92,10 @@ def maybe_create_elasticsearch_index(elasticsearch_url, index_name):
     _wait_elasticsearch_healthy(es)
 
     if es.indices.exists(index=index_name):
-        logger.info('%s index already exists at %s.' % (index_name, elasticsearch_url))
+        logger.info(
+            '%s index already exists at %s.' % (index_name, elasticsearch_url))
     else:
-        logger.info('Creating %s index at %s.' % (index_name, elasticsearch_url))
+        logger.info(
+            'Creating %s index at %s.' % (index_name, elasticsearch_url))
         es.indices.create(index=index_name, body={})
     return es

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -77,23 +77,14 @@ def _wait_elasticsearch_healthy(es):
 
 
 def maybe_create_elasticsearch_index(elasticsearch_url, index_name):
-    """Maybe create Elasticsearch index.
-
-    - Waits for Elasticsearch to be healthy
-    - Creates index only if it doesn't already exist
-
-    Args:
-        elasticsearch_url: Elasticsearch url
-        index_name: Index name. For Elasticsearch index name restrictions, see
-            https://github.com/DataBiosphere/data-explorer-indexers/issues/5#issue-308168951
-    """
+    """Creates Elasticsearchindex if it doesn't already exist."""
     es = Elasticsearch([elasticsearch_url])
 
     _wait_elasticsearch_healthy(es)
 
     if es.indices.exists(index=index_name):
         logger.info(
-            '%s index already exists at %s.' % (index_name, elasticsearch_url))
+            'Using existing %s index at %s.' % (index_name, elasticsearch_url))
     else:
         logger.info(
             'Creating %s index at %s.' % (index_name, elasticsearch_url))

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -76,10 +76,11 @@ def _wait_elasticsearch_healthy(es):
     logging.getLogger("elasticsearch").setLevel(logging.INFO)
 
 
-def init_elasticsearch(elasticsearch_url, index_name):
-    """Performs Elasticsearch initialization.
+def maybe_create_elasticsearch_index(elasticsearch_url, index_name):
+    """Maybe create Elasticsearch index.
 
-    Waits for Elasticsearch to be healthy, and creates index.
+    - Waits for Elasticsearch to be healthy
+    - Creates index only if it doesn't already exist
 
     Args:
         elasticsearch_url: Elasticsearch url
@@ -90,10 +91,9 @@ def init_elasticsearch(elasticsearch_url, index_name):
 
     _wait_elasticsearch_healthy(es)
 
-    logger.info('Deleting and recreating %s index.' % index_name)
-    try:
-        es.indices.delete(index=index_name)
-    except Exception:
-        pass
-    es.indices.create(index=index_name, body={})
+    if es.indices.exists(index=index_name):
+        logger.info('%s index already exists at %s.' % (index_name, elasticsearch_url))
+    else:
+        logger.info('Creating %s index at %s.' % (index_name, elasticsearch_url))
+        es.indices.create(index=index_name, body={})
     return es


### PR DESCRIPTION
Instead, add a step to `deploy/README.md` to delete the index.

This way, for datasets like AMP PD that need multiple indexers, the index won't be deleted at the start of every indexer run.