### PR TITLE
Friendly error message for wrong primary_key

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -89,8 +89,8 @@ def index_facet_field(es, index_name, primary_key, project_id, dataset_id,
     logger.info('%s has %d rows' % (table_name, len(df)))
 
     if not primary_key in df.columns:
-        logger.error('Primary key %s not found in %s.%s' %
-                     (primary_key, dataset_id, table_name))
+        raise ValueError('Primary key %s not found in BigQuery dataset %s.%s' %
+                         (primary_key, dataset_id, table_name))
 
     start_time = time.time()
     documents = df.to_dict(orient='records')

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -88,6 +88,10 @@ def index_facet_field(es, index_name, primary_key, project_id, dataset_id,
     logger.info('BigQuery -> pandas took %s' % elapsed_time_str)
     logger.info('%s has %d rows' % (table_name, len(df)))
 
+    if not primary_key in df.columns:
+        logger.error('Primary key %s not found in %s.%s' %
+                     (primary_key, dataset_id, table_name))
+
     start_time = time.time()
     documents = df.to_dict(orient='records')
     # Use generator so we can index large tables without having to load into


### PR DESCRIPTION
Before this PR, error is:
```
indexer_1        | Traceback (most recent call last):
indexer_1        |   File "indexer.py", line 140, in <module>
indexer_1        |     main()
indexer_1        |   File "indexer.py", line 135, in main
indexer_1        |     args.billing_project_id)
indexer_1        |   File "indexer.py", line 109, in index_facet_field
indexer_1        |     bulk(es, k)
indexer_1        |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 257, in bulk
indexer_1        |     for ok, item in streaming_bulk(client, actions, **kwargs):
indexer_1        |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 180, in streaming_bulk
indexer_1        |     client.transport.serializer):
indexer_1        |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 58, in _chunk_actions
indexer_1        |     for action, data in actions:
indexer_1        |   File "indexer.py", line 107, in <genexpr>
indexer_1        |     } for _, row in df.iterrows())
indexer_1        |   File "/usr/local/lib/python2.7/site-packages/pandas/core/series.py", line 623, in __getitem__
indexer_1        |     result = self.index.get_value(self, key)
indexer_1        |   File "/usr/local/lib/python2.7/site-packages/pandas/core/indexes/base.py", line 2574, in get_value
indexer_1        |     raise e1
indexer_1        | KeyError: u'id'
```