### PR TITLE
Remove nan's before indexing in Elasticsearch

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -95,7 +95,7 @@ def index_table(es, index_name, primary_key, table_name, billing_project_id):
             # Elasticsearch crashes when indexing nan's.
             'doc': row.dropna().to_dict(),
             'doc_as_upsert': True
-        } for col, row in df.iterrows())
+        } for _, row in df.iterrows())
 
     bulk(es, k)
     elapsed_time = time.time() - start_time


### PR DESCRIPTION
I tried indexing Baseline tables with the new `bigquery.json`.

Before this PR: I got this error because the BigQuery tables have some cells that are null:
```
elasticsearch_1    | [2018-07-03T21:58:56,122][WARN ][r.suppressed             ] path: /_bulk, params: {}
elasticsearch_1    | com.fasterxml.jackson.core.JsonParseException: Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow
elasticsearch_1    |  at [Source: org.elasticsearch.transport.netty4.ByteBufStreamInput@5c758f6f; line: 1, column: 1616]
elasticsearch_1    | 	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1702) ~[jackson-core-2.8.10.jar:2.8.10]
elasticsearch_1    | 	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:558) ~[jackson-core-2.8.10.jar:2.8.10]
elasticsearch_1    | 	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._handleUnexpectedValue(UTF8StreamJsonParser.java:2667) ~[jackson-core-2.8.10.jar:2.8.10]
elasticsearch_1    | 	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:832) ~[jackson-core-2.8.10.jar:2.8.10]
elasticsearch_1    | 	at com.fasterxml.jackson.core.JsonGenerator.copyCurrentStructure(JsonGenerator.java:1813) ~[jackson-core-2.8.10.jar:2.8.10]
elasticsearch_1    | 	at org.elasticsearch.common.xcontent.json.JsonXContentGenerator.copyCurrentStructure(JsonXContentGenerator.java:407) ~[elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.common.xcontent.XContentBuilder.copyCurrentStructure(XContentBuilder.java:1021) ~[elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.action.update.UpdateRequest.fromXContent(UpdateRequest.java:741) ~[elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.action.bulk.BulkRequest.add(BulkRequest.java:433) ~[elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.rest.action.document.RestBulkAction.prepareRequest(RestBulkAction.java:94) ~[elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:80) ~[elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:240) [elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.rest.RestController.tryAllHandlers(RestController.java:336) [elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:174) [elasticsearch-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.http.netty4.Netty4HttpServerTransport.dispatchRequest(Netty4HttpServerTransport.java:500) [transport-netty4-6.2.2.jar:6.2.2]
elasticsearch_1    | 	at org.elasticsearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:80) [transport-netty4-6.2.2.jar:6.2.2]
```
After this PR, the tables are indexed fine.