### PR TITLE
Include project/dataset/table name in index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ like:
 
 ```
 {
-  "age": "30",
+  "myproject.mytable.mydataset.age": "30",
 }
 ```
 
@@ -32,8 +32,8 @@ weight field:
 
 ```
 {
-  "age": "30",
-  "weight": "140",
+  "myproject.mytable.mydataset.age": "30",
+  "myproject.mytable.mydataset.weight": "140",
 }
 ```
 

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -80,24 +80,31 @@ def index_table(es, index_name, primary_key, table_name, billing_project_id):
                          (primary_key, table_name))
 
     start_time = time.time()
+
     # Use generator so we can index large tables without having to load into
     # memory.
-    k = (
-        {
-            '_op_type': 'update',
-            '_index': index_name,
-            # type will go away in future versions of Elasticsearch. Just use any string
-            # here.
-            '_type': 'type',
-            '_id': row[primary_key],
+    def es_actions(df):
+        for _, row in df.iterrows():
             # Remove nan's as described in
             # https://stackoverflow.com/questions/40363926/how-do-i-convert-my-dataframe-into-a-dictionary-while-ignoring-the-nan-values
             # Elasticsearch crashes when indexing nan's.
-            'doc': row.dropna().to_dict(),
-            'doc_as_upsert': True
-        } for _, row in df.iterrows())
+            row_dict = row.dropna().to_dict()
+            row_dict = {
+                table_name + '.' + k: v
+                for k, v in row_dict.iteritems()
+            }
+            yield ({
+                '_op_type': 'update',
+                '_index': index_name,
+                # type will go away in future versions of Elasticsearch. Just
+                # use any string here.
+                '_type': 'type',
+                '_id': row[primary_key],
+                'doc': row_dict,
+                'doc_as_upsert': True
+            })
 
-    bulk(es, k)
+    bulk(es, es_actions(df))
     elapsed_time = time.time() - start_time
     elapsed_time_str = time.strftime("%Hh:%Mm:%Ss", time.gmtime(elapsed_time))
     logger.info('pandas -> ElasticSearch index took %s' % elapsed_time_str)


### PR DESCRIPTION
This is needed to workaround an NHS problem where the same column name has 2 types in 2 tables. This will also eventually be needed for exporting selected cohort.