### PR TITLE
Update data-explorer network name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Run the BigQuery Indexer
           command: |
             echo ${GOOGLE_SERVICE_KEY} | base64 --decode > ${HOME}/.config/gcloud/application_default_credentials.json
-            docker network create dataexplorer_default
+            docker network create data-explorer_default
             cd bigquery
             # Run Elasticsearch in the background with the indexer in the foreground to prevent blocking the main thread
             docker-compose up -d elasticsearch

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -31,4 +31,4 @@ networks:
     external:
       # This is only needed for indexing data into an Elasticsearch container
       # from the data-explorer repo. Use the network from that repo.
-      name: dataexplorer_default
+      name: data-explorer_default

--- a/gcs/docker-compose.yml
+++ b/gcs/docker-compose.yml
@@ -24,4 +24,4 @@ networks:
     external:
       # This is only needed for indexing data into an Elasticsearch container
       # from the data-explorer repo. Use the network from that repo.
-      name: dataexplorer_default
+      name: data-explorer_default


### PR DESCRIPTION
Prior to docker-compose 1.21.0, running `docker-compose` in data-explorer repo created network dataexplorer_default.

With docker-compose 1.21.0, this changed to data-explorer_default. See "Dashes and underscores in project names are no longer stripped out." in [release notes](https://github.com/docker/compose/releases/tag/1.21.0).