### PR TITLE
Fix upsert for bulk_index_scripts

### DIFF
--- a/dataset_config/1000_genomes/bigquery.json
+++ b/dataset_config/1000_genomes/bigquery.json
@@ -23,7 +23,7 @@
 //   format is: <project>.<dataset>.<table>.<column>
 {
   "table_names": [
-      "bryancrampton-testing.data_explorer.1000_genomes_samples_manifest",
+      "bryancrampton-testing.data_explorer.1000_genomes_sample_manifest",
       "bryancrampton-testing.data_explorer.1000_genomes_sample_info"
   ],
 

--- a/dataset_config/1000_genomes/bigquery.json
+++ b/dataset_config/1000_genomes/bigquery.json
@@ -23,8 +23,8 @@
 //   format is: <project>.<dataset>.<table>.<column>
 {
   "table_names": [
-      "bryancrampton-testing.data_explorer.1000_genomes_sample_info",
-      "bryancrampton-testing.data_explorer.1000_genomes_samples_manifest"
+      "bryancrampton-testing.data_explorer.1000_genomes_samples_manifest",
+      "bryancrampton-testing.data_explorer.1000_genomes_sample_info"
   ],
 
   "participant_id_column": "participant_id",

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -117,7 +117,7 @@ def bulk_index_scripts(es, index_name, scripts_by_id):
                 '_type': 'type',
                 '_id': _id,
                 'script': script,
-                'scripted_upsert': True,
+                'upsert': {},
             })
 
     # For writing large amounts of data, the default timeout of 10s is


### PR DESCRIPTION
The use of `scripted_upsert` was incorrect, we just want to use a blank document as the `upsert`.

Makes it so that it doesn't matter if the participants or samples tables are indexed first.