### PR TITLE
Delete index at beginning of integration test instead of end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           command: |
             # TODO(bryancrampton): Refactor interaction with BigQuery / elasticsearch to support unit testing
             echo ${GOOGLE_SERVICE_KEY} | base64 --decode > ${HOME}/.config/gcloud/application_default_credentials.json
-            bigquery/tests/integration.sh ${GOOGLE_PROJECT_ID}
+            cd bigquery && tests/integration.sh ${GOOGLE_PROJECT_ID}
       - save_cache:
           key: virtualenv-{{ .Branch }}-{{ checksum "bigquery/requirements.txt" }}
           paths:

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -3,14 +3,11 @@
 # Run Data Explorer Indexer integration tests.
 #
 # Regenerate the integration_golden_index.json by running from bigquery/ (after indexing):
-# curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'bigquery/tests/integration_golden_index.json'
-#
-# tests/integration.sh <billing_project_id>
-#
+# curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'tests/integration_golden_index.json'
 
 if (( $# != 1 ))
 then
-  echo "Usage: tests/tests.sh <billing_project_id>"
+  echo "Usage: tests/integration.sh <billing_project_id>"
   echo "  where <billing_project_id> is the GCP project billed for BigQuery usage"
   echo "Run this script from bigquery/ directory"
   exit 1
@@ -31,7 +28,7 @@ billing_project_id=$1
 docker network create data-explorer_default
 
 # Run Elasticsearch in the background with the indexer in the foreground to prevent blocking the main thread.
-#docker-compose up -d elasticsearch
+docker-compose up -d elasticsearch
 waitForClusterHealthy
 curl -XDELETE localhost:9200/1000_genomes
 

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -2,25 +2,39 @@
 #
 # Run Data Explorer Indexer integration tests.
 #
-# Regenerate the integration_golden_index.json by running from project root (after indexing):
+# Regenerate the integration_golden_index.json by running from bigquery/ (after indexing):
 # curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'bigquery/tests/integration_golden_index.json'
 #
-# bigquery/tests/integration.sh <billing_project_id>
+# tests/integration.sh <billing_project_id>
 #
 
 if (( $# != 1 ))
 then
-  echo "Usage: biquery/tests/tests.sh <billing_project_id>"
+  echo "Usage: tests/tests.sh <billing_project_id>"
   echo "  where <billing_project_id> is the GCP project billed for BigQuery usage"
-  echo "Run this script from project root"
+  echo "Run this script from bigquery/ directory"
   exit 1
 fi
 
+waitForClusterHealthy() {
+  status=''
+  while [[ $status != 'yellow' ]]; do
+    echo "Waiting for Elasticsearch cluster to be healthy"
+    sleep 1
+    status=$(curl -s localhost:9200/_cluster/health | jq -r '.status')
+  done
+  echo "Elasticsearch cluster is now healthy"
+}
+
+
 billing_project_id=$1
 docker network create data-explorer_default
-cd bigquery
+
 # Run Elasticsearch in the background with the indexer in the foreground to prevent blocking the main thread.
-docker-compose up -d elasticsearch
+#docker-compose up -d elasticsearch
+waitForClusterHealthy
+curl -XDELETE localhost:9200/1000_genomes
+
 BILLING_PROJECT_ID=${billing_project_id} docker-compose up --build indexer
 # For some reason index isn't available right after indexer terminates, so sleep.
 sleep 5
@@ -38,5 +52,4 @@ if [ "$DIFF" != "" ]; then
 fi
 
 rm tests/actual_index.json
-curl -XDELETE localhost:9200/1000_genomes
 docker-compose stop

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -15,7 +15,8 @@ fi
 
 waitForClusterHealthy() {
   status=''
-  while [[ $status != 'yellow' ]]; do
+  # For some reason, cluster health is green on CircleCI
+  while [[ $status != 'yellow' && $status != 'green' ]]; do
     echo "Waiting for Elasticsearch cluster to be healthy"
     sleep 1
     status=$(curl -s localhost:9200/_cluster/health | jq -r '.status')


### PR DESCRIPTION
This seems cleaner to me.

For example, say:
- Make typo in bigquery.json
- Run indexer, index is incorrect
- Fix bigquery.json
- Run test

Before this PR, test would fail. After this PR, test will correctly pass.

Also, run test from bigquery/ instead of project root. With project root, I kept having to change directories, since docker-compose is run from bigquery.