### PR TITLE
Wait before creating samples JSON export file

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -334,6 +334,8 @@ def main():
                     sample_id_column, sample_file_columns)
         index_fields(es, index_name + '_fields', table, sample_id_column)
 
+    # Ensure all of the newly indexed documents are loaded into ES.
+    time.sleep(5)
     if os.path.exists(deploy_config_path):
         deploy_config = indexer_util.parse_json_file(deploy_config_path)
         create_samples_json_export_file(es, index_name,


### PR DESCRIPTION
Encountered some occasional issues where not all of the samples were present in the export samples JSON file. Interestingly this was only happening on linux (not my mac). Sleeping for 5 seconds before scanning through the index seems to resolve the issue––similarly to how we do for the integration test.