### PR TITLE
Remove BILLING_PROJECT_ID flag

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -7,13 +7,12 @@ into a local Elasticsearch container.
 
 * If `~/.config/gcloud/application_default_credentials.json` doesn't exist,
 create it by running `gcloud auth application-default login`.
-* Determine the project that will be billed for querying the BigQuery tables.
-Your account must have `bigquery.jobs.create` permission on this project; this
-includes any project where you have the Viewer/Editor/Owner role.
+* Copy [`dataset_config/template/deploy.json`](https://github.com/DataBiosphere/data-explorer-indexers/blob/master/dataset_config/template/deploy.json)
+to `dataset_config/1000_genomes/deploy.json`. Set `project_id` to a project
+where you are at least Project Editor.
 * If `docker network ls` doesn't show `data-explorer_default`, run:
 `docker network create data-explorer_default`
-* From `bigquery` directory, run:
- `BILLING_PROJECT_ID=<billing project id> docker-compose up --build`
+* From `bigquery` directory, run: `docker-compose up --build`
 * View Elasticsearch index:
   ```
   http://localhost:9200/_cat/indices?v
@@ -50,7 +49,7 @@ Your account must have `bigquery.jobs.create` permission on this project; this
 includes any project where you have the Viewer/Editor/Owner role.
 * Run the indexer. From `bigquery` directory, run:
   ```
-  BILLING_PROJECT_ID=<billing project id> DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build indexer
+  DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build indexer
   ```
 * View Elasticsearch index:
   ```

--- a/bigquery/deploy/bq-indexer-cronjob.yaml.templ
+++ b/bigquery/deploy/bq-indexer-cronjob.yaml.templ
@@ -25,8 +25,7 @@ spec:
             command: ["python", "/app/indexer.py"]
             args: [
               "--elasticsearch_url", "http://ELASTICSEARCH_URL:9200/",
-              "--dataset_config_dir", "/app/dataset_config",
-              "--billing_project_id", "PROJECT_ID"
+              "--dataset_config_dir", "/app/dataset_config"
             ]
 
           restartPolicy: Never

--- a/bigquery/deploy/bq-indexer.yaml.templ
+++ b/bigquery/deploy/bq-indexer.yaml.templ
@@ -19,8 +19,7 @@ spec:
         command: ["python", "/app/indexer.py"]
         args: [
           "--elasticsearch_url", "http://ELASTICSEARCH_URL:9200/",
-          "--dataset_config_dir", "/app/dataset_config",
-          "--billing_project_id", "PROJECT_ID"
+          "--dataset_config_dir", "/app/dataset_config"
         ]
 
       restartPolicy: Never

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
       # For convenience, include 1000 Genomes by default.
       - DATASET_CONFIG_DIR=${DATASET_CONFIG_DIR:-dataset_config/1000_genomes}
-      - BILLING_PROJECT_ID=${BILLING_PROJECT_ID}
     volumes:
       # Expose gcloud credentials. This is only needed for
       # local runs, which are authenticated as a user. This is not needed for

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -2,21 +2,15 @@
 #
 # Run Data Explorer Indexer integration tests.
 #
+# From bigquery/, run: tests/integration.sh
+#
 # Regenerate golden files by running from bigquery/:
 #   docker-compose up -d elasticsearch
 #   curl -XDELETE localhost:9200/1000_genomes && curl -XDELETE localhost:9200/1000_genomes_fields
-#   BILLING_PROJECT_ID=google.com:api-project-360728701457 docker-compose up --build indexer
+#   docker-compose up --build indexer
 #   curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'tests/1000_genomes_golden.json'
 #   curl -s 'http://localhost:9200/1000_genomes/_mappings?pretty' | jq -rS '.' > 'tests/1000_genomes_mappings_golden.json'
 #   curl -s 'http://localhost:9200/1000_genomes_fields/_search?size=200' | jq -rS '.hits.hits' > 'tests/1000_genomes_fields_golden.json'
-
-if (( $# != 1 ))
-then
-  echo "Usage: tests/integration.sh <billing_project_id>"
-  echo "  where <billing_project_id> is the GCP project billed for BigQuery usage"
-  echo "Run this script from bigquery/ directory"
-  exit 1
-fi
 
 waitForClusterHealthy() {
   status=''
@@ -30,7 +24,6 @@ waitForClusterHealthy() {
 }
 
 
-billing_project_id=$1
 docker network create data-explorer_default
 
 # Run Elasticsearch in the background with the indexer in the foreground to prevent blocking the main thread.
@@ -39,7 +32,7 @@ waitForClusterHealthy
 curl -XDELETE localhost:9200/1000_genomes
 curl -XDELETE localhost:9200/1000_genomes_fields
 
-BILLING_PROJECT_ID=${billing_project_id} docker-compose up --build indexer
+docker-compose up --build indexer
 # For some reason index isn't available right after indexer terminates, so sleep.
 sleep 5
 

--- a/dataset_config/template/deploy.json
+++ b/dataset_config/template/deploy.json
@@ -1,3 +1,10 @@
+// project_id is used for:
+// - Elasticsearch and indexer GCP deployment
+// - Paying for BigQuery query to read dataset BigQuery tables
+// - Storing files for sending data to Terra
+//
+// The project in this file may be different from the project containing
+// dataset BigQuery tables.
 {
   "project_id": "PROJECT_ID_TO_DEPLOY_TO"
 }


### PR DESCRIPTION
From indexer.py:
```
bigquery.Client(project=args.billing_project_id)
```

My next PR will make the indexer work on the new, large NHS table. In it, I will write a temporary table to the deploy dataset. The PR will create another client:
```
bigquery.Client(project=deploy_project_id)
```
So both billing_project_id and deploy_project_id will be charged for billing. To avoid confusion, just use deploy project for all billing and delete BILLING_PROJECT_ID flag.

Why we have BILLING_PROJECT_ID:
First, indexer.py was implemented and run locally. At this time, there was no deploy.json/deploy project. We added BILLING_PROJECT_ID because we didn't have permission to bill the project containing dataset BigQuery tables (eg AMP PD project).

FYI @malathi13 