### PR TITLE
Add env for customizing ES heap size

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -38,6 +38,10 @@ create it by running `gcloud auth application-default login`.
     ```
     docker-compose up -d elasticsearch
     ```
+  * If ES crashes due to OOM, you can increase [heap size](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html):
+    ```
+    ES_JAVA_OPTS="-Xms10g -Xmx10g" docker-compose up -d elasticsearch
+    ```
   * If you do not intend to run the Data Explorer UI after this, and just want
   to inspect the index in Elasticsearch, run inside this repo from the
   `bigquery` directory:

--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -38,15 +38,15 @@ create it by running `gcloud auth application-default login`.
     ```
     docker-compose up -d elasticsearch
     ```
-  * If ES crashes due to OOM, you can increase [heap size](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html):
-    ```
-    ES_JAVA_OPTS="-Xms10g -Xmx10g" docker-compose up -d elasticsearch
-    ```
   * If you do not intend to run the Data Explorer UI after this, and just want
   to inspect the index in Elasticsearch, run inside this repo from the
   `bigquery` directory:
     ```
     docker-compose up -d elasticsearch
+    ```
+  * If ES crashes due to OOM, you can increase [heap size](https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html):
+    ```
+    ES_JAVA_OPTS="-Xms10g -Xmx10g" docker-compose up -d elasticsearch
     ```
 * Determine the project that will be billed for querying the BigQuery tables.
 Your account must have `bigquery.jobs.create` permission on this project; this

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -10,8 +10,7 @@ services:
       # deployments; bootstrap checks are still enabled for production
       # deployments.
       - "transport.host=localhost"
-      - "HEAP_SIZE=${HEAP_SIZE:-256m}"
-      - "ES_JAVA_OPTS=-Xms$HEAP_SIZE -Xmx$HEAP_SIZE"
+      - ES_JAVA_OPTS=${ES_JAVA_OPTS:--Xms256m -Xmx256m}
   indexer:
     build:
       # Context is project root, to pick up indexer_util and dataset_config

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       # deployments; bootstrap checks are still enabled for production
       # deployments.
       - "transport.host=localhost"
-      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "HEAP_SIZE=${HEAP_SIZE:-256m}"
+      - "ES_JAVA_OPTS=-Xms$HEAP_SIZE -Xmx$HEAP_SIZE"
   indexer:
     build:
       # Context is project root, to pick up indexer_util and dataset_config

--- a/bigquery/docker-compose.yml
+++ b/bigquery/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # deployments; bootstrap checks are still enabled for production
       # deployments.
       - "transport.host=localhost"
-      - ES_JAVA_OPTS=${ES_JAVA_OPTS:--Xms256m -Xmx256m}
+      - ES_JAVA_OPTS
   indexer:
     build:
       # Context is project root, to pick up indexer_util and dataset_config


### PR DESCRIPTION
Switch elasticsearch back to starting with the default heap size, but add an easy ENV for customizing it when indexing larger datasets with a more powerful computer.

`docker-compose up elasticsearch`: Uses the ES default of 256MB for the java heap, which should work on all computers but may run out of memory when indexing large datasets.
`ES_JAVA_OPTS="-Xms10g -Xmx10g" docker-compose up elasticsearch`: Uses 10GB for the java heap, which may not work on all computers but will perform far better for large datasets.

FYI @malathi13 