### PR TITLE
Increase request timeout to 300s

### DIFF
--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -150,9 +150,8 @@ def bulk_index_scripts(es, index_name, scripts_by_id):
             })
 
     _prepare_for_indexing(es)
-    # For writing large amounts of data, the default timeout of 10s is
-    # sometimes not enough.
-    bulk(es, es_actions(scripts_by_id), request_timeout=120)
+    # For large datasets, the default timeout of 10s is sometimes not enough.
+    bulk(es, es_actions(scripts_by_id), request_timeout=300)
     _complete_indexing(es)
 
 
@@ -173,7 +172,6 @@ def bulk_index_docs(es, index_name, docs_by_id):
             })
 
     _prepare_for_indexing(es)
-    # For writing large amounts of data, the default timeout of 10s is
-    # sometimes not enough.
-    bulk(es, es_actions(docs_by_id), request_timeout=120)
+    # For large datasets, the default timeout of 10s is sometimes not enough.
+    bulk(es, es_actions(docs_by_id), request_timeout=300)
     _complete_indexing(es)


### PR DESCRIPTION
I saw this while periodically while indexing NHS:
```
indexer_1_23dcc3c190fa | Traceback (most recent call last):
indexer_1_23dcc3c190fa |   File "/usr/local/lib/python2.7/site-packages/elasticsearch/connection/http_urllib3.py", line 149, in perform_request
indexer_1_23dcc3c190fa |     response = self.pool.urlopen(method, url, body, retries=False, headers=request_headers, **kw)
indexer_1_23dcc3c190fa |   File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 639, in urlopen
indexer_1_23dcc3c190fa |     _stacktrace=sys.exc_info()[2])
indexer_1_23dcc3c190fa |   File "/usr/local/lib/python2.7/site-packages/urllib3/util/retry.py", line 333, in increment
indexer_1_23dcc3c190fa |     raise six.reraise(type(error), error, _stacktrace)
indexer_1_23dcc3c190fa |   File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 601, in urlopen
indexer_1_23dcc3c190fa |     chunked=chunked)
indexer_1_23dcc3c190fa |   File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 389, in _make_request
indexer_1_23dcc3c190fa |     self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
indexer_1_23dcc3c190fa |   File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 309, in _raise_timeout
indexer_1_23dcc3c190fa |     raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
indexer_1_23dcc3c190fa | ReadTimeoutError: HTTPConnectionPool(host='elasticsearch', port=9200): Read timed out. (read timeout=120)
```
Increasing the timeout seems to have fixed them. The retries might no longer be needed, but I guess it doesn't hurt to keep them.