### PR TITLE
Use PodDisruptionBudgets to prevent ES breaking after nodes are auto-upgraded

### DIFF
--- a/kubernetes-elasticsearch-cluster/deploy-es.sh
+++ b/kubernetes-elasticsearch-cluster/deploy-es.sh
@@ -64,19 +64,25 @@ if [ -n "$node_pool_machine_type" ]; then
   sed -i -e "s/-Xms2g -Xmx2g/-Xms${heap_mem}m -Xmx${heap_mem}m/g" es-data-stateful-deploy.yaml
 fi
 
-# Do not fail on errors (from set -o errexit) when because things might not exist.
+# Do not fail on errors (from set -o errexit) because things might not exist.
 kubectl delete -f es-discovery-svc.yaml || true
 kubectl delete -f es-svc.yaml || true
-kubectl delete -f es-master-svc.yaml || true
+# Delete data nodes before master nodes. If master nodes were deleted first,
+# deleting data nodes would fail because after the master nodes deletion, data
+# pods are in "Pods have warnings" state.
 kubectl delete -f es-data-svc.yaml || true
-kubectl delete -f es-master-stateful.yaml || true
 kubectl delete -f es-data-stateful-deploy.yaml || true
-
+kubectl delete -f es-data-pdb.yaml || true
+kubectl delete -f es-master-svc.yaml || true
+kubectl delete -f es-master-stateful.yaml || true
+kubectl delete -f es-master-pdb.yaml || true
 
 kubectl create -f es-discovery-svc.yaml
 kubectl create -f es-svc.yaml
 kubectl create -f es-master-svc.yaml
+kubectl create -f es-master-pdb.yaml
 kubectl create -f es-data-svc.yaml
+kubectl create -f es-data-pdb.yaml
 
 kubectl create -f es-master-stateful.yaml
 kubectl rollout status -f es-master-stateful.yaml

--- a/kubernetes-elasticsearch-cluster/es-data-pdb.yaml
+++ b/kubernetes-elasticsearch-cluster/es-data-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: elasticsearch-data
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: data

--- a/kubernetes-elasticsearch-cluster/es-master-pdb.yaml
+++ b/kubernetes-elasticsearch-cluster/es-master-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: elasticsearch-master
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: master


### PR DESCRIPTION
Baseline Baseline explorer had a problem where all shards were unassigned:
```
bash-4.4# curl localhost:9200/_cat/shards?h=index,shard,prirep,state,unassigned.at
baseline_health_study_fields 1 p UNASSIGNED 2019-01-18T11:00:06.654Z
baseline_health_study_fields 1 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study_fields 4 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study_fields 4 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study_fields 3 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study_fields 3 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study_fields 2 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study_fields 2 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study_fields 0 p UNASSIGNED 2019-01-18T11:00:06.654Z
baseline_health_study_fields 0 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study        1 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study        1 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study        4 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study        4 r UNASSIGNED 2019-01-18T10:58:10.947Z
baseline_health_study        3 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study        3 r UNASSIGNED 2019-01-18T10:58:10.948Z
baseline_health_study        2 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study        2 r UNASSIGNED 2019-01-18T10:58:10.793Z
baseline_health_study        0 p UNASSIGNED 2019-01-18T11:00:06.653Z
baseline_health_study        0 r UNASSIGNED 2019-01-18T10:58:10.948Z

bash-4.4# curl localhost:9200/_cluster/allocation/explain
{"index":"baseline_health_study","shard":3,"primary":true,"current_state":"unassigned","unassigned_info":{"reason":"NODE_LEFT","at":"2019-01-18T11:00:06.653Z","details":"node_left[rrGx4AcvRJiPcNZ-8E4ONg]","last_allocation_status":"no_valid_shard_copy"},"can_allocate":"no_valid_shard_copy","allocate_explanation":"cannot allocate because a previous copy of the primary shard existed but can no longer be found on the nodes in the cluster","node_allocation_decisions":[{"node_id":"9iCEqMAQR96wYFXmC5XYwQ","node_name":"es-data-56794cb655-hr2jq","transport_address":"10.4.0.4:9300","node_decision":"no","store":{"found":false}},{"node_id":"ZsjxY8m6SNKj5bLBt1S97g","node_name":"es-data-56794cb655-hsfcl","transport_address":"10.4.1.13:9300","node_decision":"no","store":{"found":false}}]}bash-4.4# curl localhost:9200/_cluster/allocation/explain?pretty
{
  "index" : "baseline_health_study",
  "shard" : 3,
  "primary" : true,
  "current_state" : "unassigned",
  "unassigned_info" : {
    "reason" : "NODE_LEFT",
    "at" : "2019-01-18T11:00:06.653Z",
    "details" : "node_left[rrGx4AcvRJiPcNZ-8E4ONg]",
    "last_allocation_status" : "no_valid_shard_copy"
  },
  "can_allocate" : "no_valid_shard_copy",
  "allocate_explanation" : "cannot allocate because a previous copy of the primary shard existed but can no longer be found on the nodes in the cluster",
  "node_allocation_decisions" : [
    {
      "node_id" : "9iCEqMAQR96wYFXmC5XYwQ",
      "node_name" : "es-data-56794cb655-hr2jq",
      "transport_address" : "10.4.0.4:9300",
      "node_decision" : "no",
      "store" : {
        "found" : false
      }
    },
    {
      "node_id" : "ZsjxY8m6SNKj5bLBt1S97g",
      "node_name" : "es-data-56794cb655-hsfcl",
      "transport_address" : "10.4.1.13:9300",
      "node_decision" : "no",
      "store" : {
        "found" : false
      }
    }
  ]
} 
```
The 3 nodes were auto-upgraded:
![upgrade1](https://user-images.githubusercontent.com/10929390/51864861-baeff580-22f9-11e9-934a-6354e3b1fe29.png)
![upgrade2](https://user-images.githubusercontent.com/10929390/51864863-bcb9b900-22f9-11e9-88a4-02806889fa4d.png)

Kubernetes waits until first node is pingable before bringing down second node. However, there is time between "node is pingable" and "ES cluster is healthy". Looks like Elasticsearch doesn't handle auto-upgrades well.

Fix is to use PodDisruptionBudgets from [here](https://github.com/pires/kubernetes-elasticsearch-cluster#availability). Hopefully that will prevent future occurrences of this problem.

---

Also change the order of deleting StatefulSets. Before this PR:
- master StatefulSet deleted (before data StatefulSet)
- This caused data pods to have status "Pods have warnings":
![data](https://user-images.githubusercontent.com/10929390/51864950-f38fcf00-22f9-11e9-9aef-9c4094003b2d.png)
- This caused `kubectl delete -f es-data-stateful-deploy.yaml` to not work. It would hang for a couple minutes and then say: `error: error when stopping "kubernetes-elasticsearch-cluster/es-data-stateful-deploy.yaml": timed out waiting for "es-data" to be synced`

I ran `deploy-es.sh` several times and things work now.
