### PR TITLE
Move local-ui-index-gke instructions to deploy README

### DIFF
--- a/bigquery/README.md
+++ b/bigquery/README.md
@@ -117,10 +117,8 @@ message in the logs. Try increasing Docker's memory, for example from 2 GB to
 A 2 GB table can take 4 hours to index. Here are tips so you don't have to wait
 for reindexing.
 
-#### Index not in GKE
-
-This section applies if your Elasticsearch index is not yet in GKE. For example,
-you may be working on a change to the indexer.
+Note that if your index is already on GKE and you want to test out the UI,
+[follow these instructions instead](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/deploy#running-a-local-ui-with-an-index-from-gke).
 
 Always pass `--no-recreate` to `docker-compose up elasticsearch`.
 
@@ -138,21 +136,3 @@ So the basic flow is:
 - In another window, run `DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build indexer`
 - Then if you want to run Data Explorer UI, don't include `elasticsearch` in
   `docker-compose up`: `docker-compose up --build -t 0 nginx_proxy ui apise kibana`
-
-#### Index in GKE
-
-This section applies if your Elasticsearch index is in GKE. For example,
-your index is static; you are working on a change to the UI or API server.
-
-This only works on Linux machines because [docker host networking](https://docs.docker.com/network/host/)
-only works on Linux machines.
-
-```
-gcloud config set project MY_PROJECT
-gcloud container clusters get-credentials elasticsearch-cluster --zone MY_ZONE
-kubectl port-forward es-data-0 9200:9200
-# Run this from inside data-explorer repo
-git cherry-pick --no-commit 6cee79dab14fc9707b5936345e35bd0b54578425
-DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build -t 0 ui apise nginx_proxy
-```
-Now UI will be at `localhost:4401`.

--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -161,6 +161,7 @@ only works on Linux machines.
 gcloud config set project MY_PROJECT
 gcloud container clusters get-credentials elasticsearch-cluster --zone MY_ZONE
 kubectl port-forward es-data-0 9200:9200
+# Now Chrome tab with localhost:9200/_cat/indices?v works
 # Run this from inside data-explorer repo
 git cherry-pick --no-commit 6cee79dab14fc9707b5936345e35bd0b54578425
 DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build -t 0 ui apise nginx_proxy

--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -31,8 +31,8 @@ example, for Terra group `foo`:
   This is needed to view GKE monitoring charts.
 * Set up service account  
 [Following the principle of least privilege](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform#why_use_service_accounts),
-we require using a new `indexer` service account with only the necessary permissions. 
-Only this service account will be given access to the BigQuery tables. Some of the deploy scripts 
+we require using a new `indexer` service account with only the necessary permissions.
+Only this service account will be given access to the BigQuery tables. Some of the deploy scripts
 assume the service account has this name.
   * Create service account
     * Navigate to `IAM & Admin > Service Accounts > Create Service Account`.
@@ -151,3 +151,18 @@ In `deploy.json`, try increasing `node_pool_num_nodes` to 5.
 By default, Elasticsearch indices use 5 shards. With 5 replicas, each replica
 will have 1 shard. (As opposed to one replica having 2 shards and being a
 bottleneck.)
+
+## Running a local UI with an index from GKE
+
+This only works on Linux machines because [docker host networking](https://docs.docker.com/network/host/)
+only works on Linux machines.
+
+```
+gcloud config set project MY_PROJECT
+gcloud container clusters get-credentials elasticsearch-cluster --zone MY_ZONE
+kubectl port-forward es-data-0 9200:9200
+# Run this from inside data-explorer repo
+git cherry-pick --no-commit 6cee79dab14fc9707b5936345e35bd0b54578425
+DATASET_CONFIG_DIR=dataset_config/<my dataset> docker-compose up --build -t 0 ui apise nginx_proxy
+```
+Now UI will be at `localhost:4401`.


### PR DESCRIPTION
deploy README seems like a better place since it's GKE related.