### PR TITLE
Willyn/bulk at end

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -486,7 +486,8 @@ def main():
                         sample_file_columns)
         index_table(es, bq_client, storage_client, index_name, table,
                     participant_id_column, sample_id_column,
-                    sample_file_columns, deploy_project_id, all_table_documents, all_sample_documents)
+                    sample_file_columns, deploy_project_id,
+                    all_table_documents, all_sample_documents)
     indexer_util.bulk_index_scripts(es, index_name, all_sample_documents)
     indexer_util.bulk_index_docs(es, index_name, all_table_documents)
 

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -236,7 +236,7 @@ def add_table_to_participant_docs(es, bq_client, storage_client, index_name,
 
 
 def add_table_to_field_docs(es, index_name, table, sample_id_column,
-                             field_docs):
+                            field_docs):
     table_name = _table_name_from_table(table)
     logger.info('Indexing %s into %s.' % (table_name, index_name))
 
@@ -492,7 +492,7 @@ def main():
                         participant_id_column, sample_id_column,
                         sample_file_columns)
         field_docs = add_table_to_field_docs(es, fields_index_name, table,
-                                              sample_id_column, field_docs)
+                                             sample_id_column, field_docs)
         participant_docs = add_table_to_participant_docs(
             es, bq_client, storage_client, index_name, table,
             participant_id_column, sample_id_column, sample_file_columns,

--- a/bigquery/tests/1000_genomes_fields_golden.json
+++ b/bigquery/tests/1000_genomes_fields_golden.json
@@ -1,81 +1,11 @@
 [
   {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Family_ID",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.DNA_Source_from_Coriell",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Family ID",
-      "name": "Family_ID"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.ET_Pilot_Platforms",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "exon targetted sequencing platforms,",
-      "name": "ET_Pilot_Platforms"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_E_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "phase1 exome sequencing centers",
-      "name": "Phase1_E_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_phase1_chrY_Deletions",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The sample is genotyepd in the chrY phase1 deletions",
-      "name": "Has_phase1_chrY_Deletions"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Affy_Free",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_LC_Affy_Free"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Passed_QC",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "These are binary flags showing if the sample passed QC, All samples which have passed QC have bam files. Only samples which have both exome and low coverage data are found under ftp/data and listed in the standard alignment index. The small number of other samples are found in ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/phase3_EX_or_LC_only_alignment/",
-      "name": "LC_Passed_QC"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Omni_Genotypes",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Omni Genotypes in ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20120131_omni_genotypes_and_intensities/Omni25_genotypes_2141_samples.b37.vcf.gz   ",
-      "name": "Has_Omni_Genotypes"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Affy_6_0_Genotypes",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Affy 6.0 Genotypes in  ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20121128_corriel_p3_sample_genotypes/",
-      "name": "Has_Affy_6_0_Genotypes"
+      "description": "This was the annotated DNA Source from Coriell     ",
+      "name": "DNA_Source_from_Coriell"
     },
     "_type": "type"
   },
@@ -90,192 +20,22 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_16_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.ET_Pilot_Centers",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 16 multi-sample VCF with 2504 samples",
-      "name": "chr_16_vcf"
+      "description": "exon targetted sequencing centers,",
+      "name": "ET_Pilot_Centers"
     },
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_22_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.ET_Pilot_Platforms",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 22 multi-sample VCF with 2504 samples",
-      "name": "chr_22_vcf"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_20_bai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage chromosome 20 BAI",
-      "name": "wgs_low_cov_chr_20_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_20_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome chromosome 20 BAM",
-      "name": "exome_chr_20_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_unmapped_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome unmapped BAS",
-      "name": "exome_unmapped_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS high coverage BAM",
-      "name": "wgs_high_cov_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.participant_id",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Identical to Sample in bigquery-public-data.human_genome_variants.1000_genomes_sample_info. This column was created for demonstration purposes.",
-      "name": "participant_id"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Relationship",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Relationship to other members of the family",
-      "name": "Relationship"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Non_Paternity",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for annotated non paternal relationships",
-      "name": "Non_Paternity"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Grandparents",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for any grand parents",
-      "name": "Grandparents"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Avuncular",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for any avuncular relationships",
-      "name": "Avuncular"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Super_Population_Description",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "From ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/20131219.superpopulations.tsv",
-      "name": "Super_Population_Description"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_Low_Coverage_Pilot",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The sample is in the low coverage pilot experiment",
-      "name": "In_Low_Coverage_Pilot"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Pilot_Platforms",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "low coverage pilot sequencing platforms ",
-      "name": "LC_Pilot_Platforms"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Sequence_in_Phase1",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Has sequence low coverage sequence in the 20101123.sequence.index file or exome sequence in the 20110522 sequence index file",
-      "name": "Has_Sequence_in_Phase1"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_project_LC_platform",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "low coverage sequencing platform for final sequencing round",
-      "name": "Main_project_LC_platform"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Total_Exome_Sequence",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The total amount of exome sequence available",
-      "name": "Total_Exome_Sequence"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.X_Targets_Covered_to_20x_or_greater",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The percentage of targets covered to 20x or greater as calculated by the picard function CalculateHsMetrics using these targets ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/exome_pull_down_targets_phases1_and_2/20120518.consensus.annotation.bed",
-      "name": "X_Targets_Covered_to_20x_or_greater"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Omni_Free",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_E_Omni_Free"
+      "description": "exon targetted sequencing platforms,",
+      "name": "ET_Pilot_Platforms"
     },
     "_type": "type"
   },
@@ -286,6 +46,46 @@
     "_source": {
       "description": "Both Indel ratios are the ratio of insertions to deletions found in that sample using a quick test (based on samtools). If the ratio is higher than 5 the sample is withdrawn.",
       "name": "E_Indel_Ratio"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.E_Passed_QC",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "These are binary flags showing if the sample passed QC, All samples which have passed QC have bam files. Only samples which have both exome and low coverage data are found under ftp/data and listed in the standard alignment index. The small number of other samples are found in ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/phase3_EX_or_LC_only_alignment/",
+      "name": "E_Passed_QC"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.HC_Pilot_Centers",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "high coverage sequencing centers",
+      "name": "HC_Pilot_Centers"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.HC_Pilot_Platforms",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "high coverage sequencing platforms",
+      "name": "HC_Pilot_Platforms"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Affy_6_0_Genotypes",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Affy 6.0 Genotypes in  ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20121128_corriel_p3_sample_genotypes/",
+      "name": "Has_Affy_6_0_Genotypes"
     },
     "_type": "type"
   },
@@ -310,6 +110,26 @@
     "_type": "type"
   },
   {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Omni_Genotypes",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Omni Genotypes in ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20120131_omni_genotypes_and_intensities/Omni25_genotypes_2141_samples.b37.vcf.gz   ",
+      "name": "Has_Omni_Genotypes"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Phase1_chrY_SNPS",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "The sample is genotyped in the chrY phase1 snp set",
+      "name": "Has_Phase1_chrY_SNPS"
+    },
+    "_type": "type"
+  },
+  {
     "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Sequence_from_Blood_in_Index",
     "_index": "1000_genomes_fields",
     "_score": 1,
@@ -320,252 +140,42 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_6_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Sequence_in_Phase1",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 6 multi-sample VCF with 2504 samples",
-      "name": "chr_6_vcf"
+      "description": "Has sequence low coverage sequence in the 20101123.sequence.index file or exome sequence in the 20110522 sequence index file",
+      "name": "Has_Sequence_in_Phase1"
     },
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_7_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_phase1_chrMT_SNPs",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 7 multi-sample VCF with 2504 samples",
-      "name": "chr_7_vcf"
+      "description": "The sample is genotyped in the phase1 chrMT snps",
+      "name": "Has_phase1_chrMT_SNPs"
     },
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_9_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_phase1_chrY_Deletions",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 9 multi-sample VCF with 2504 samples",
-      "name": "chr_9_vcf"
+      "description": "The sample is genotyepd in the chrY phase1 deletions",
+      "name": "Has_phase1_chrY_Deletions"
     },
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_13_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_Exon_Targetted_Pilot",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 13 multi-sample VCF with 2504 samples",
-      "name": "chr_13_vcf"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_14_vcf",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Chromosome 14 multi-sample VCF with 2504 samples",
-      "name": "chr_14_vcf"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_17_vcf",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Chromosome 17 multi-sample VCF with 2504 samples",
-      "name": "chr_17_vcf"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_20_vcf",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Chromosome 20 multi-sample VCF with 2504 samples",
-      "name": "chr_20_vcf"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_20_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage chromosome 20 BAS",
-      "name": "wgs_low_cov_chr_20_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_unmapped_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage unmapped BAM",
-      "name": "wgs_low_cov_unmapped_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_20_bai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome chromosome 20 BAI",
-      "name": "exome_chr_20_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome mapped BAM",
-      "name": "exome_mapped_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_bai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome mapped BAI",
-      "name": "exome_mapped_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Unexpected_Parent_Child",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample id for unexpected parent child relationships",
-      "name": "Unexpected_Parent_Child"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Siblings",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for any siblings",
-      "name": "Siblings"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Third_Order",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for any third order cryptic relations. As mentioned above, this analysis was not as widely run as the other relatedness analyses and as such there may still be unannotated third order relations in the set",
-      "name": "Third_Order"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Super_Population",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "From ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/20131219.superpopulations.tsv",
-      "name": "Super_Population"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.participant_id",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Identical to Sample in bigquery-public-data.human_genome_variants.1000_genomes_sample_info. This column was created for demonstration purposes.",
-      "name": "participant_id"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.HC_Pilot_Platforms",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "high coverage sequencing platforms",
-      "name": "HC_Pilot_Platforms"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_LC_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "phase1 low coverage sequencing centers",
-      "name": "Phase1_LC_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_E_Platform",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "phase1 exome sequencing platforms",
-      "name": "Phase1_E_Platform"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_Phase1_Integrated_Variant_Set",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The sample is genotyped in the phase1 integrated call set on autosomes and chrX",
-      "name": "In_Phase1_Integrated_Variant_Set"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Omni_Chip",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_E_Omni_Chip"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Omni_Free",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_LC_Omni_Free"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Omni_Chip",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_LC_Omni_Chip"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.E_Passed_QC",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "These are binary flags showing if the sample passed QC, All samples which have passed QC have bam files. Only samples which have both exome and low coverage data are found under ftp/data and listed in the standard alignment index. The small number of other samples are found in ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/phase3_EX_or_LC_only_alignment/",
-      "name": "E_Passed_QC"
+      "description": "The Sample is in the exon targetted pilot experiment",
+      "name": "In_Exon_Targetted_Pilot"
     },
     "_type": "type"
   },
@@ -580,22 +190,272 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_5_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_High_Coverage_Pilot",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 5 multi-sample VCF with 2504 samples",
-      "name": "chr_5_vcf"
+      "description": "The sample is in the high coverage pilot",
+      "name": "In_High_Coverage_Pilot"
     },
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_8_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_Low_Coverage_Pilot",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 8 multi-sample VCF with 2504 samples",
-      "name": "chr_8_vcf"
+      "description": "The sample is in the low coverage pilot experiment",
+      "name": "In_Low_Coverage_Pilot"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_Phase1_Integrated_Variant_Set",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "The sample is genotyped in the phase1 integrated call set on autosomes and chrX",
+      "name": "In_Phase1_Integrated_Variant_Set"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Indel_Ratio",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Both Indel ratios are the ratio of insertions to deletions found in that sample using a quick test (based on samtools). If the ratio is higher than 5 the sample is withdrawn.",
+      "name": "LC_Indel_Ratio"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Non_Duplicated_Aligned_Coverage",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "The non duplicated aligned coverage for the low coverage sequence data.  This was calculated using the ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/alignment_indices/20130502.low_coverage.alignment.index.bas.gz file, the (mapped bases - duplicated bases) was summed for each sample and divided by 2.75GB and rounded to 2dp",
+      "name": "LC_Non_Duplicated_Aligned_Coverage"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Passed_QC",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "These are binary flags showing if the sample passed QC, All samples which have passed QC have bam files. Only samples which have both exome and low coverage data are found under ftp/data and listed in the standard alignment index. The small number of other samples are found in ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/phase3_EX_or_LC_only_alignment/",
+      "name": "LC_Passed_QC"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Pilot_Centers",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "low coverage pilot sequencing centers",
+      "name": "LC_Pilot_Centers"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Pilot_Platforms",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "low coverage pilot sequencing platforms ",
+      "name": "LC_Pilot_Platforms"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_Project_E_Centers",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome sequencing centers for the final sequencing round",
+      "name": "Main_Project_E_Centers"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_Project_E_Platform",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome sequencing platform for the final sequencing round",
+      "name": "Main_Project_E_Platform"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_project_LC_Centers",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "low coverage sequencing centers for final sequencing round",
+      "name": "Main_project_LC_Centers"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_project_LC_platform",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "low coverage sequencing platform for final sequencing round",
+      "name": "Main_project_LC_platform"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_E_Centers",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "phase1 exome sequencing centers",
+      "name": "Phase1_E_Centers"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_E_Platform",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "phase1 exome sequencing platforms",
+      "name": "Phase1_E_Platform"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_LC_Centers",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "phase1 low coverage sequencing centers",
+      "name": "Phase1_LC_Centers"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_LC_Platform",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "phase1 low coverage sequencing platforms",
+      "name": "Phase1_LC_Platform"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Total_Exome_Sequence",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "The total amount of exome sequence available",
+      "name": "Total_Exome_Sequence"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Total_LC_Sequence",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "The total amount of low coverage sequence available",
+      "name": "Total_LC_Sequence"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Affy_Chip",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_E_Affy_Chip"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Affy_Free",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_E_Affy_Free"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Omni_Chip",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_E_Omni_Chip"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Omni_Free",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_E_Omni_Free"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Affy_Chip",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_LC_Affy_Chip"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Affy_Free",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_LC_Affy_Free"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Omni_Chip",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_LC_Omni_Chip"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Omni_Free",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
+      "name": "VerifyBam_LC_Omni_Free"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.X_Targets_Covered_to_20x_or_greater",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "The percentage of targets covered to 20x or greater as calculated by the picard function CalculateHsMetrics using these targets ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/exome_pull_down_targets_phases1_and_2/20120518.consensus.annotation.bed",
+      "name": "X_Targets_Covered_to_20x_or_greater"
     },
     "_type": "type"
   },
@@ -620,202 +480,32 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_11_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage chromosome 11 BAM",
-      "name": "wgs_low_cov_chr_11_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage mapped BAS",
-      "name": "wgs_low_cov_mapped_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_cram",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage mapped CRAM",
-      "name": "wgs_low_cov_mapped_cram"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_11_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome chromosome 11 BAM",
-      "name": "exome_chr_11_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_20_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome chromosome 20 BAS",
-      "name": "exome_chr_20_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome mapped BAS",
-      "name": "exome_mapped_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_crai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome mapped CRAI",
-      "name": "exome_mapped_crai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_csra",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome mapped CSRA",
-      "name": "exome_mapped_csra"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Population",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "3 letter population code",
-      "name": "Population"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Population_Description",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Description of Population",
-      "name": "Population_Description"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Gender",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Gender",
-      "name": "Gender"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Half_Siblings",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for any half siblings",
-      "name": "Half_Siblings"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.HC_Pilot_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "high coverage sequencing centers",
-      "name": "HC_Pilot_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_Phase1_chrY_SNPS",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The sample is genotyped in the chrY phase1 snp set",
-      "name": "Has_Phase1_chrY_SNPS"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Total_LC_Sequence",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The total amount of low coverage sequence available",
-      "name": "Total_LC_Sequence"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_Project_E_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome sequencing centers for the final sequencing round",
-      "name": "Main_Project_E_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Affy_Free",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_E_Affy_Free"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_E_Affy_Chip",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_E_Affy_Chip"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.VerifyBam_LC_Affy_Chip",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Value from UMich's VerifyBamID BAM QC program http://genome.sph.umich.edu/wiki/VerifyBamID.  The Free measures use a statistical model based on the haplotypes discovered by the chip. The Chip measure considers the genotypes available for that individual from that chip. We use greater than 3% as a cut off for our our low coverage samples and greater than 3.5% for our exome samples.",
-      "name": "VerifyBam_LC_Affy_Chip"
-    },
-    "_type": "type"
-  },
-  {
     "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_12_vcf",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
       "description": "Chromosome 12 multi-sample VCF with 2504 samples",
       "name": "chr_12_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_13_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 13 multi-sample VCF with 2504 samples",
+      "name": "chr_13_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_14_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 14 multi-sample VCF with 2504 samples",
+      "name": "chr_14_vcf"
     },
     "_type": "type"
   },
@@ -830,6 +520,26 @@
     "_type": "type"
   },
   {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_16_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 16 multi-sample VCF with 2504 samples",
+      "name": "chr_16_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_17_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 17 multi-sample VCF with 2504 samples",
+      "name": "chr_17_vcf"
+    },
+    "_type": "type"
+  },
+  {
     "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_18_vcf",
     "_index": "1000_genomes_fields",
     "_score": 1,
@@ -840,212 +550,12 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_11_bai",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_19_vcf",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "WGS low coverage chromosome 11 BAI",
-      "name": "wgs_low_cov_chr_11_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_11_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage chromosome 11 BAS",
-      "name": "wgs_low_cov_chr_11_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_20_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage chromosome 20 BAM",
-      "name": "wgs_low_cov_chr_20_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_crai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage mapped CRAI",
-      "name": "wgs_low_cov_mapped_crai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_unmapped_bai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage unmapped BAI",
-      "name": "wgs_low_cov_unmapped_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_11_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome chromosome 11 BAS",
-      "name": "exome_chr_11_bas"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_bai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS high coverage BAI",
-      "name": "wgs_high_cov_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_cram",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS high coverage CRAM",
-      "name": "wgs_high_cov_cram"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Unknown_Second_Order",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "sample ids for any unknown second order relations",
-      "name": "Unknown_Second_Order"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.sample_id",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Identical to Sample in bigquery-public-data.human_genome_variants.1000_genomes_sample_info. This column was created for demonstration purposes.",
-      "name": "sample_id"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Pilot_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "low coverage pilot sequencing centers",
-      "name": "LC_Pilot_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_High_Coverage_Pilot",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The sample is in the high coverage pilot",
-      "name": "In_High_Coverage_Pilot"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.In_Exon_Targetted_Pilot",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The Sample is in the exon targetted pilot experiment",
-      "name": "In_Exon_Targetted_Pilot"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.ET_Pilot_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "exon targetted sequencing centers,",
-      "name": "ET_Pilot_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Phase1_LC_Platform",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "phase1 low coverage sequencing platforms",
-      "name": "Phase1_LC_Platform"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Has_phase1_chrMT_SNPs",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The sample is genotyped in the phase1 chrMT snps",
-      "name": "Has_phase1_chrMT_SNPs"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_project_LC_Centers",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "low coverage sequencing centers for final sequencing round",
-      "name": "Main_project_LC_Centers"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Non_Duplicated_Aligned_Coverage",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "The non duplicated aligned coverage for the low coverage sequence data.  This was calculated using the ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/alignment_indices/20130502.low_coverage.alignment.index.bas.gz file, the (mapped bases - duplicated bases) was summed for each sample and divided by 2.75GB and rounded to 2dp",
-      "name": "LC_Non_Duplicated_Aligned_Coverage"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.Main_Project_E_Platform",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Exome sequencing platform for the final sequencing round",
-      "name": "Main_Project_E_Platform"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.LC_Indel_Ratio",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "Both Indel ratios are the ratio of insertions to deletions found in that sample using a quick test (based on samtools). If the ratio is higher than 5 the sample is withdrawn.",
-      "name": "LC_Indel_Ratio"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.DNA_Source_from_Coriell",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "This was the annotated DNA Source from Coriell     ",
-      "name": "DNA_Source_from_Coriell"
+      "description": "Chromosome 19 multi-sample VCF with 2504 samples",
+      "name": "chr_19_vcf"
     },
     "_type": "type"
   },
@@ -1056,6 +566,36 @@
     "_source": {
       "description": "Chromosome 1 multi-sample VCF with 2504 samples",
       "name": "chr_1_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_20_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 20 multi-sample VCF with 2504 samples",
+      "name": "chr_20_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_21_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 21 multi-sample VCF with 2504 samples",
+      "name": "chr_21_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_22_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 22 multi-sample VCF with 2504 samples",
+      "name": "chr_22_vcf"
     },
     "_type": "type"
   },
@@ -1090,22 +630,52 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_19_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_5_vcf",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 19 multi-sample VCF with 2504 samples",
-      "name": "chr_19_vcf"
+      "description": "Chromosome 5 multi-sample VCF with 2504 samples",
+      "name": "chr_5_vcf"
     },
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_21_vcf",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_6_vcf",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Chromosome 21 multi-sample VCF with 2504 samples",
-      "name": "chr_21_vcf"
+      "description": "Chromosome 6 multi-sample VCF with 2504 samples",
+      "name": "chr_6_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_7_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 7 multi-sample VCF with 2504 samples",
+      "name": "chr_7_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_8_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 8 multi-sample VCF with 2504 samples",
+      "name": "chr_8_vcf"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_9_vcf",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Chromosome 9 multi-sample VCF with 2504 samples",
+      "name": "chr_9_vcf"
     },
     "_type": "type"
   },
@@ -1130,52 +700,102 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_bam",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage mapped BAM",
-      "name": "wgs_low_cov_mapped_bam"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_bai",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage mapped BAI",
-      "name": "wgs_low_cov_mapped_bai"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_csra",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage mapped CSRA",
-      "name": "wgs_low_cov_mapped_csra"
-    },
-    "_type": "type"
-  },
-  {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_unmapped_bas",
-    "_index": "1000_genomes_fields",
-    "_score": 1,
-    "_source": {
-      "description": "WGS low coverage unmapped BAS",
-      "name": "wgs_low_cov_unmapped_bas"
-    },
-    "_type": "type"
-  },
-  {
     "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_11_bai",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
       "description": "Exome chromosome 11 BAI",
       "name": "exome_chr_11_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_11_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome chromosome 11 BAM",
+      "name": "exome_chr_11_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_11_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome chromosome 11 BAS",
+      "name": "exome_chr_11_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_20_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome chromosome 20 BAI",
+      "name": "exome_chr_20_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_20_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome chromosome 20 BAM",
+      "name": "exome_chr_20_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_chr_20_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome chromosome 20 BAS",
+      "name": "exome_chr_20_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome mapped BAI",
+      "name": "exome_mapped_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome mapped BAM",
+      "name": "exome_mapped_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome mapped BAS",
+      "name": "exome_mapped_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_crai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome mapped CRAI",
+      "name": "exome_mapped_crai"
     },
     "_type": "type"
   },
@@ -1190,12 +810,12 @@
     "_type": "type"
   },
   {
-    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_unmapped_bam",
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_mapped_csra",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
-      "description": "Exome unmapped BAM",
-      "name": "exome_unmapped_bam"
+      "description": "Exome mapped CSRA",
+      "name": "exome_mapped_csra"
     },
     "_type": "type"
   },
@@ -1210,12 +830,392 @@
     "_type": "type"
   },
   {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_unmapped_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome unmapped BAM",
+      "name": "exome_unmapped_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.exome_unmapped_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Exome unmapped BAS",
+      "name": "exome_unmapped_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.participant_id",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Identical to Sample in bigquery-public-data.human_genome_variants.1000_genomes_sample_info. This column was created for demonstration purposes.",
+      "name": "participant_id"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.sample_id",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Identical to Sample in bigquery-public-data.human_genome_variants.1000_genomes_sample_info. This column was created for demonstration purposes.",
+      "name": "sample_id"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS high coverage BAI",
+      "name": "wgs_high_cov_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS high coverage BAM",
+      "name": "wgs_high_cov_bam"
+    },
+    "_type": "type"
+  },
+  {
     "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_crai",
     "_index": "1000_genomes_fields",
     "_score": 1,
     "_source": {
       "description": "WGS high coverage CRAI",
       "name": "wgs_high_cov_crai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_high_cov_cram",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS high coverage CRAM",
+      "name": "wgs_high_cov_cram"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_11_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage chromosome 11 BAI",
+      "name": "wgs_low_cov_chr_11_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_11_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage chromosome 11 BAM",
+      "name": "wgs_low_cov_chr_11_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_11_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage chromosome 11 BAS",
+      "name": "wgs_low_cov_chr_11_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_20_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage chromosome 20 BAI",
+      "name": "wgs_low_cov_chr_20_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_20_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage chromosome 20 BAM",
+      "name": "wgs_low_cov_chr_20_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_chr_20_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage chromosome 20 BAS",
+      "name": "wgs_low_cov_chr_20_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage mapped BAI",
+      "name": "wgs_low_cov_mapped_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage mapped BAM",
+      "name": "wgs_low_cov_mapped_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage mapped BAS",
+      "name": "wgs_low_cov_mapped_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_crai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage mapped CRAI",
+      "name": "wgs_low_cov_mapped_crai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_cram",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage mapped CRAM",
+      "name": "wgs_low_cov_mapped_cram"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_mapped_csra",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage mapped CSRA",
+      "name": "wgs_low_cov_mapped_csra"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_unmapped_bai",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage unmapped BAI",
+      "name": "wgs_low_cov_unmapped_bai"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_unmapped_bam",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage unmapped BAM",
+      "name": "wgs_low_cov_unmapped_bam"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.wgs_low_cov_unmapped_bas",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "WGS low coverage unmapped BAS",
+      "name": "wgs_low_cov_unmapped_bas"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Avuncular",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for any avuncular relationships",
+      "name": "Avuncular"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Family_ID",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Family ID",
+      "name": "Family_ID"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Gender",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Gender",
+      "name": "Gender"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Grandparents",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for any grand parents",
+      "name": "Grandparents"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Half_Siblings",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for any half siblings",
+      "name": "Half_Siblings"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Non_Paternity",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for annotated non paternal relationships",
+      "name": "Non_Paternity"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Population",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "3 letter population code",
+      "name": "Population"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Population_Description",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Description of Population",
+      "name": "Population_Description"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Relationship",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Relationship to other members of the family",
+      "name": "Relationship"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Siblings",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for any siblings",
+      "name": "Siblings"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Super_Population",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "From ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/20131219.superpopulations.tsv",
+      "name": "Super_Population"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Super_Population_Description",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "From ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/20131219.superpopulations.tsv",
+      "name": "Super_Population_Description"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Third_Order",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for any third order cryptic relations. As mentioned above, this analysis was not as widely run as the other relatedness analyses and as such there may still be unannotated third order relations in the set",
+      "name": "Third_Order"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Unexpected_Parent_Child",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample id for unexpected parent child relationships",
+      "name": "Unexpected_Parent_Child"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.Unknown_Second_Order",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "sample ids for any unknown second order relations",
+      "name": "Unknown_Second_Order"
+    },
+    "_type": "type"
+  },
+  {
+    "_id": "verily-public-data.human_genome_variants.1000_genomes_participant_info.participant_id",
+    "_index": "1000_genomes_fields",
+    "_score": 1,
+    "_source": {
+      "description": "Identical to Sample in bigquery-public-data.human_genome_variants.1000_genomes_sample_info. This column was created for demonstration purposes.",
+      "name": "participant_id"
     },
     "_type": "type"
   }

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -37,7 +37,9 @@ curl -XDELETE localhost:9200/1000_genomes_fields
 
 docker-compose up --build indexer
 # For some reason index isn't available right after indexer terminates, so sleep.
+echo "Indexer successful, sleeping for 5 seconds now"
 sleep 5
+echo "Sleep done"
 
 # Validate the correct number of documents were indexed.
 DOC_COUNT=$(curl -s 'http://localhost:9200/1000_genomes/_search' | jq -r '.hits.total')
@@ -45,6 +47,8 @@ if [ "$DOC_COUNT" != "3500" ]; then
   echo "Number of documents is incorrect, expected 3500, got $DOC_COUNT"
   exit 1
 fi
+
+echo "Diff 1 pass"
 
 # Write the index out to a file in order to diff.
 curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'tests/1000_genomes.json'
@@ -55,6 +59,8 @@ if [ "$DIFF" != "" ]; then
   exit 1
 fi
 
+echo "Diff 2 pass"
+
 # Write the mappings out to a file in order to diff.
 curl -s 'http://localhost:9200/1000_genomes/_mappings' | jq -rS '.' > 'tests/1000_genomes_mappings.json'
 DIFF=$(diff tests/1000_genomes_mappings_golden.json tests/1000_genomes_mappings.json)
@@ -64,8 +70,10 @@ if [ "$DIFF" != "" ]; then
   exit 1
 fi
 
+echo "Diff 3 pass"
+
 # Write the fields index out to a file in order to diff.
-curl -s 'http://localhost:9200/1000_genomes_fields/_search?size=200' | jq -rS '.hits.hits' > 'tests/1000_genomes_fields.json'
+curl -s 'http://localhost:9200/1000_genomes_fields/_search?size=200' | jq -rS '.hits.hits' | jq -r '.|=sort_by(._id)' > 'tests/1000_genomes_fields.json'
 DIFF=$(diff tests/1000_genomes_fields_golden.json tests/1000_genomes_fields.json)
 if [ "$DIFF" != "" ]; then
   echo "Fields index does not match golden json file, diff:"
@@ -73,8 +81,10 @@ if [ "$DIFF" != "" ]; then
   exit 1
 fi
 
+echo "Diff 4 pass"
 
 rm tests/1000_genomes.json
 rm tests/1000_genomes_mappings.json
 rm tests/1000_genomes_fields.json
 docker-compose stop
+echo "Test Success!!"

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -136,7 +136,7 @@ def bulk_index_scripts(es, index_name, scripts_by_id):
     # Use generator so we can index arbitrarily large iterators (like tables),
     # without having to load into memory.
     def es_actions(scripts_by_id):
-        for _id, script in scripts_by_id:
+        for _id, script in scripts_by_id.iteritems():
             yield ({
                 '_op_type': 'update',
                 '_index': index_name,
@@ -159,7 +159,7 @@ def bulk_index_docs(es, index_name, docs_by_id):
     # Use generator so we can index arbitrarily large iterators (like tables),
     # without having to load into memory.
     def es_actions(docs_by_id):
-        for _id, doc in docs_by_id:
+        for _id, doc in docs_by_id.iteritems():
             yield ({
                 '_op_type': 'update',
                 '_index': index_name,

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -132,35 +132,20 @@ def _complete_indexing(es):
     })
 
 
-def bulk_index_docs(es, index_name, docs_by_id, op_type='create'):
+def bulk_index_docs(es, index_name, docs_by_id):
     # es_docs is a dict containing documents to be indexed into Elasticsearch.
     # Key is participant id; value is document contents.
     def es_actions(docs_by_id):
         for _id, doc in docs_by_id.iteritems():
-            if op_type == 'create':
-                es_action = {
-                    '_op_type': 'create',
-                    '_index': index_name,
-                    # type will go away in future versions of Elasticsearch. Just
-                    # use any string here.
-                    '_type': 'type',
-                    '_id': _id,
-                    '_source': doc,
-                }
-            elif op_type == 'update':
-                es_action = {
-                    '_op_type': 'update',
-                    '_index': index_name,
-                    # type will go away in future versions of Elasticsearch. Just
-                    # use any string here.
-                    '_type': 'type',
-                    '_id': _id,
-                    'doc': doc,
-                    'doc_as_upsert': True,
-                }
-            else:
-                raise Exception('Invalid op type')
-            yield (es_action)
+            yield ({
+                '_op_type': 'create',
+                '_index': index_name,
+                # type will go away in future versions of Elasticsearch. Just
+                # use any string here.
+                '_type': 'type',
+                '_id': _id,
+                '_source': doc,
+            })
 
     _prepare_for_indexing(es)
     # For large datasets, the default timeout of 10s is sometimes not enough.

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -133,8 +133,8 @@ def _complete_indexing(es):
 
 
 def bulk_index_docs(es, index_name, docs_by_id):
-    # es_docs is a dict containing documents to be indexed into Elasticsearch.
-    # Key is participant id; value is document contents.
+    # docs_by_id is a dict containing documents to be indexed into Elasticsearch.
+    # Key is document id; value is document contents.
     def es_actions(docs_by_id):
         for _id, doc in docs_by_id.iteritems():
             yield ({

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -132,44 +132,19 @@ def _complete_indexing(es):
     })
 
 
-def bulk_index_scripts(es, index_name, scripts_by_id):
-    # Use generator so we can index arbitrarily large iterators (like tables),
-    # without having to load into memory.
-    def es_actions(scripts_by_id):
-        for _id, script in scripts_by_id.iteritems():
-            yield ({
-                '_op_type': 'update',
-                '_index': index_name,
-                # type will go away in future versions of Elasticsearch. Just
-                # use any string here.
-                '_type': 'type',
-                '_id': _id,
-                'scripted_upsert': True,
-                'script': script,
-                'upsert': {},
-            })
-
-    _prepare_for_indexing(es)
-    # For large datasets, the default timeout of 10s is sometimes not enough.
-    bulk(es, es_actions(scripts_by_id), request_timeout=300)
-    _complete_indexing(es)
-
-
-def bulk_index_docs(es, index_name, docs_by_id):
-    # Use generator so we can index arbitrarily large iterators (like tables),
-    # without having to load into memory.
+def bulk_index_docs(es, index_name, docs_by_id, op_type='create'):
+    # es_docs is a dict containing documents to be indexed into Elasticsearch.
+    # Key is participant id; value is document contents.
     def es_actions(docs_by_id):
         for _id, doc in docs_by_id.iteritems():
-            yield ({
-                '_op_type': 'update',
+            yield (doc.update({
+                '_op_type': op_type,
                 '_index': index_name,
                 # type will go away in future versions of Elasticsearch. Just
                 # use any string here.
                 '_type': 'type',
                 '_id': _id,
-                'doc': doc,
-                'doc_as_upsert': True
-            })
+            }))
 
     _prepare_for_indexing(es)
     # For large datasets, the default timeout of 10s is sometimes not enough.


### PR DESCRIPTION
Fixes #127 . 

Previously, for each table in the dataset we would push its indexed data up to elasticsearch. Unfortunately it seems that each additional table gets slower as it re-indexes. The idea of this fix is that we keep all table data in memory before pushing it up to the elasticsearch table. Here we do it for both samples and participants. 

Testing with the baseline cdr data finished fairly quickly (~30-40 mins) and used an additional roughly 1.1 GB of memoryc

Testing with the 1000 genomes data (to test samples) was also successful. 