### PR TITLE
Turn on autoupgrade for GKE cluster

### DIFF
--- a/kubernetes-elasticsearch-cluster/create-cluster.sh
+++ b/kubernetes-elasticsearch-cluster/create-cluster.sh
@@ -63,4 +63,4 @@ if [ "$node_pool_num_nodes" == "null" ] || [ -z "$node_pool_num_nodes" ]; then
 	node_pool_num_nodes="3"
 fi
 
-gcloud container clusters create elasticsearch-cluster --num-nodes=${node_pool_num_nodes} --machine-type=${node_pool_machine_type} --service-account=indexer@${project_id}.iam.gserviceaccount.com --zone=${zone}
+gcloud container clusters create elasticsearch-cluster --num-nodes=${node_pool_num_nodes} --machine-type=${node_pool_machine_type} --service-account=indexer@${project_id}.iam.gserviceaccount.com --zone=${zone} --enable-autoupgrade


### PR DESCRIPTION
So we get security updates. The [PodDisruptionBudgets](https://github.com/DataBiosphere/data-explorer-indexers/pull/124) should keep Data Explorer working during an upgrade.

I ran the script and confirmed in GKE UI that autoupgrade is now on.