### PR TITLE
Update scripts to reindex with no downtime

### DIFF
--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -101,6 +101,28 @@ assume the service account has this name.
   kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
   ```
 
+## Reindex with no downtime
+* Creating a new index in the existing elasticsearch cluster would cause downtime
+  for your users. If you need to reindex, we reccommend you have the app engine 
+  point to a new elasticsearch service containing the new index. Run the following
+  scripts from project root to create new clusters, deploy elasticsearch, and 
+  reindex:
+  ```
+  kubernetes-elasticsearch-cluster/create-cluster.sh DATASET
+  kubernetes-elasticsearch-cluster/deploy-es.sh DATASET
+  bigquery/deploy/deploy-indexer.sh DATASET
+  ```
+* Verify the indexer was successful:
+  ```
+  kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
+  ```
+* Then run the deploy-api script in the data-explorer repo.
+* Verify that your new version is deployed, then delete the old clusters:
+  ```
+  gcloud container clusters list # find old cluster name
+  gcloud container clusters delete OLD_CLUSTER_NAME --zone ZONE
+  ```
+
 ## Elasticsearch performance tuning
 
 For a 2.3G BigQuery table, we have found the following `deploy.json` works well:

--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -122,6 +122,9 @@ assume the service account has this name.
   gcloud container clusters list # find old cluster name
   gcloud container clusters delete OLD_CLUSTER_NAME --zone ZONE
   ```
+* Since these scripts esentially double the amount of clusters, you may need
+  to request more quota for certain resources from GCP. To do so, go to the
+  [quotas page on GCP.](https://pantheon.corp.google.com/iam-admin/quotas?usage=USED)
 
 ## Elasticsearch performance tuning
 

--- a/bigquery/deploy/deploy-indexer.sh
+++ b/bigquery/deploy/deploy-indexer.sh
@@ -18,15 +18,21 @@ fi
 dataset=$1
 project_id=$(jq --raw-output '.project_id' dataset_config/${dataset}/deploy.json)
 
+# Need to get cluster name by sorting the list of clusters, and choosing to
+# use the one with the greatest timestamp (most recent)
+cluster_line=$(gcloud container clusters list | grep elasticsearch-cluster- | sort -rn -k1 | head -n1)
+cluster_name=$(echo $cluster_line | awk '{print $1}')
+zone=$(echo $cluster_line | awk '{print $2}')
+
 bold=$(tput bold)
 normal=$(tput sgr0)
-echo "Deploying BigQuery indexer for ${bold}dataset ${dataset}${normal} to ${bold}project ${project_id}${normal}"
+echo "Deploying BigQuery indexer in cluster ${bold}$cluster_name${normal} for" \
+  "${bold}dataset" "$dataset${normal} in ${bold}project $project_id${normal}"
 echo
 
 # Initialize gcloud and kubectl commands
 gcloud config set project ${project_id}
-zone=$(gcloud container clusters list | grep elasticsearch-cluster | awk '{print $2}')
-gcloud container clusters get-credentials elasticsearch-cluster --zone ${zone}
+gcloud container clusters get-credentials ${cluster_name} --zone ${zone}
 
 # Create bigquery/deploy/bq-indexer.yaml from bigquery/deploy/bq-indexer.yaml.templ
 elasticsearch_url=$(kubectl get svc elasticsearch | grep elasticsearch | awk '{print $4}')
@@ -46,3 +52,7 @@ kubectl create configmap dataset-config --from-file=../../dataset_config/${datas
 # it may not yet exist.
 kubectl delete -f bq-indexer.yaml || true
 kubectl create -f bq-indexer.yaml
+
+echo "Indexer is running now. Monitor the logs by running \`kubectl logs -f \$(kubectl get pods | awk '/bq-indexer/ {print \$1;exit}')\`"
+echo ""
+echo "Verify the indexer was successful by running \`kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v\`"


### PR DESCRIPTION
Tested by:
1) Have a data-explorer already deployed with 1000_genomes data.
2) Run the scripts. Make sure the data-explorer does not go down during this time.
3) Once the scripts run, verify data-explorer is running off the new version.
4) Delete the old cluster. Verify data-explorer is still running. 