### PR TITLE
Create standalone script setup-gcloud.sh

### DIFF
--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -59,75 +59,51 @@ assume the service account has this name.
 
 
 ## Run Elasticsearch on GKE
-* From project root, run:
-  ```
-  kubernetes-elasticsearch-cluster/deploy-es.sh DATASET
-  ```
-  Where DATASET is the name of the config directory in `dataset_config`.
-* Test that Elasticsearch is up:
-  ```
-  kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
-  ```
+From project root, run:
+```
+kubernetes-elasticsearch-cluster/deploy-es.sh DATASET
+# Test that Elasticsearch is up
+kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
+```
+Where DATASET is the name of the config directory in `dataset_config`.
 
 ## Run Indexer on GKE
-* If you did the "Run Elasticsearch on GKE" step a while ago, run
-  these commands to point `gcloud` and `kubectl` to the right project.
-  ```
-  # See what projects gcloud and kubectl are configured for
-  gcloud config get-value project
-  kubectl config current-context
-  # Point gcloud and kubetl to the right project
-  gcloud config set project PROJECT
-  gcloud container clusters get-credentials elasticsearch-cluster --zone ZONE
-  ```
-  Where `ZONE` is the
-  [zone](https://console.cloud.google.com/kubernetes/list) in which
-  elasticsearch-cluster is running, e.g. `us-central1-a`.
-* We recommend you delete the index, to start from a clean slate.
-  ```
-  kubectl exec -it es-data-0 -- curl -XDELETE localhost:9200/DATASET*
-  ```
-  Where DATASET is the name of the config directory in `dataset_config`.
-* Make sure the files in `dataset_config/DATASET` are filled out.
-  * Make sure `deploy.json` (and the `authorization_domain` field in
-    `dataset.json`, if the dataset is private) are filled out.
-* From project root, run:
-  ```
-  bigquery/deploy/deploy-indexer.sh DATASET
-  kubectl logs -f $(kubectl get pods | awk '/bq-indexer/ {print $1;exit}')
-  ```
-* Verify the indexer was successful:
-  ```
-  kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
-  ```
+Make sure the files in `dataset_config/DATASET` are filled out, Including `deploy.json`, and the `authorization_domain` field in
+`dataset.json`, if the dataset is private.
+
+Run indexer:
+```
+util/setup-gcloud.sh DATASET
+# We recommend deleting the index to start from a clean slate
+kubectl exec -it es-data-0 -- curl -XDELETE localhost:9200/DATASET*
+bigquery/deploy/deploy-indexer.sh DATASET
+kubectl logs -f $(kubectl get pods | awk '/bq-indexer/ {print $1;exit}')
+# Verily indexing was successful
+kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
+```
 
 ## Reindex with no downtime
-* If you don't have any users and aren't worried about downtime, the easiest
-  way to reindex is to simply rerun deploy-indexer.sh.
-  ```
-  # We recommend deleting the index to start from a clean slate
-  kubectl exec -it es-data-0 -- curl -XDELETE localhost:9200/DATASET*
-  bigquery/deploy/deploy-indexer.sh DATASET
-  # Verily indexing was successful
-  kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
-  ```
-* If you have users and don't want them to experience downtime, you can create
-  a second cluster.
-  ```
-  kubernetes-elasticsearch-cluster/create-cluster.sh DATASET
-  kubernetes-elasticsearch-cluster/deploy-es.sh DATASET
-  # Verily elasticsearch was deployed
-  kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
-  bigquery/deploy/deploy-indexer.sh DATASET
-  # Verily indexing was successful
-  kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
-  # Run from data-explorer repo
-  deploy/deploy-api.sh DATASET
-  ```
-* After verifying Data Explorer UI works, don't forget to **delete the old cluster.**
-* Since these scripts esentially double the amount of clusters, you may need
-  to request more quota for certain resources from GCP. To do so, go to the
-  [quotas page on GCP.](https://pantheon.corp.google.com/iam-admin/quotas?usage=USED)
+If you don't have any users and aren't worried about downtime, the easiest
+way to reindex is to simply rerun the commands in the previous section.
+
+If you have users and don't want them to experience downtime, you can create
+a second cluster:
+```
+kubernetes-elasticsearch-cluster/create-cluster.sh DATASET
+kubernetes-elasticsearch-cluster/deploy-es.sh DATASET
+# Verily elasticsearch was deployed
+kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
+bigquery/deploy/deploy-indexer.sh DATASET
+# Verily indexing was successful
+kubectl exec -it es-data-0 curl localhost:9200/_cat/indices?v
+# Run from data-explorer repo
+deploy/deploy-api.sh DATASET
+```
+After verifying Data Explorer UI works, don't forget to **delete the old cluster.**
+
+Since these scripts essentially double the amount of clusters, you may need
+to request more quota for certain resources from GCP. To do so, go to the
+[quotas page on GCP.](https://console.cloud.google.com/iam-admin/quotas?usage=USED)
 
 ## Elasticsearch performance tuning
 
@@ -183,8 +159,7 @@ This only works on Linux machines because [docker host networking](https://docs.
 only works on Linux machines.
 
 ```
-gcloud config set project MY_PROJECT
-gcloud container clusters get-credentials elasticsearch-cluster --zone MY_ZONE
+util/setup-gcloud.sh DATASET
 kubectl port-forward es-data-0 9200:9200
 # Now Chrome tab with localhost:9200/_cat/indices?v works
 # Run this from inside data-explorer repo

--- a/bigquery/deploy/README.md
+++ b/bigquery/deploy/README.md
@@ -143,12 +143,9 @@ give the data nodes more cpu. We can do this by changing the data node
 
 ### Query performance
 
-If your Data Explorer UI has [enable_search_values](https://github.com/DataBiosphere/data-explorer/blob/2daf10777470b17f3f43df1685eca0e41323389b/dataset_config/template/ui.json#L24)
-set to true, Elasticsearch queries may be slow. For example, if I type `pre`
-into the Data Explorer UI search box, it may take 5+ seconds before I get
-results back.
+If you type something into search box and it takes more than 5 seconds for
+results to appear, try increasing `node_pool_num_nodes` to 5.
 
-In `deploy.json`, try increasing `node_pool_num_nodes` to 5.
 By default, Elasticsearch indices use 5 shards. With 5 replicas, each replica
 will have 1 shard. (As opposed to one replica having 2 shards and being a
 bottleneck.)

--- a/bigquery/deploy/deploy-indexer.sh
+++ b/bigquery/deploy/deploy-indexer.sh
@@ -16,23 +16,16 @@ then
 fi
 
 dataset=$1
-project_id=$(jq --raw-output '.project_id' dataset_config/${dataset}/deploy.json)
-# Initialize gcloud and kubectl commands
-gcloud config set project ${project_id}
 
-# Need to get cluster name by sorting the list of clusters, and choosing to
-# use the one with the greatest timestamp (most recent)
-cluster_line=$(gcloud container clusters list | grep elasticsearch-cluster- | sort -rn -k1 | head -n1)
-cluster_name=$(echo $cluster_line | awk '{print $1}')
-zone=$(echo $cluster_line | awk '{print $2}')
+util/setup-gcloud.sh ${dataset}
+project_id=$(kubectl config current-context | cut -d "_" -f 2)
 
 bold=$(tput bold)
 normal=$(tput sgr0)
-echo "Deploying BigQuery indexer in cluster ${bold}$cluster_name${normal} for" \
-  "${bold}dataset" "$dataset${normal} in ${bold}project $project_id${normal}"
 echo
-
-gcloud container clusters get-credentials ${cluster_name} --zone ${zone}
+echo "Deploying BigQuery indexer for ${bold}dataset $dataset${normal} in" \
+  "${bold}project $project_id${normal}"
+echo
 
 # Create bigquery/deploy/bq-indexer.yaml from bigquery/deploy/bq-indexer.yaml.templ
 elasticsearch_url=$(kubectl get svc elasticsearch | grep elasticsearch | awk '{print $4}')

--- a/kubernetes-elasticsearch-cluster/deploy-es.sh
+++ b/kubernetes-elasticsearch-cluster/deploy-es.sh
@@ -12,22 +12,17 @@ then
 fi
 
 dataset=$1
-project_id=$(jq --raw-output '.project_id' dataset_config/${dataset}/deploy.json)
-gcloud config set project ${project_id}
 
-# Need to get cluster name by sorting the list of clusters, and choosing to
-# use the one with the greatest timestamp (most recent)
-cluster_line=$(gcloud container clusters list | grep elasticsearch-cluster- | sort -rn -k1 | head -n1)
-cluster_name=$(echo $cluster_line | awk '{print $1}')
-zone=$(echo $cluster_line | awk '{print $2}')
+util/setup-gcloud.sh ${dataset}
+project_id=$(kubectl config current-context | cut -d "_" -f 2)
+zone=$(kubectl config current-context | cut -d "_" -f 3)
 
 bold=$(tput bold)
 normal=$(tput sgr0)
-echo "Deploying Elasticsearch in cluster ${bold}$cluster_name${normal} for" \
-  "${bold}dataset" "$dataset${normal} in ${bold}project $project_id${normal}"
 echo
-
-gcloud container clusters get-credentials ${cluster_name} --zone ${zone}
+echo "Deploying Elasticsearch for ${bold}dataset $dataset${normal} in" \
+  "${bold}project $project_id${normal}"
+echo
 
 # select (.!=null) makes jq return empty string instead of null
 # See https://github.com/stedolan/jq/issues/354#issuecomment-46641827

--- a/util/setup-gcloud.sh
+++ b/util/setup-gcloud.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Configure gcloud and kubectl for a dataset.
+
+set -o errexit
+set -o nounset
+
+if (( $# != 1 ))
+then
+  echo "Usage: util/setup-gcloud.sh <dataset>"
+  echo "  where <dataset> is the name of a directory in dataset_config/"
+  echo "Run this script from project root"
+  exit 1
+fi
+
+dataset=$1
+project_id=$(jq --raw-output '.project_id' dataset_config/${dataset}/deploy.json)
+
+gcloud config set project ${project_id}
+echo "gcloud project set to $(gcloud config get-value project)"
+
+# Need to get cluster name by sorting the list of clusters, and choosing to
+# use the one with the greatest timestamp (most recent)
+cluster_line=$(gcloud container clusters list | grep elasticsearch-cluster- | sort -rn -k1 | head -n1)
+cluster_name=$(echo $cluster_line | awk '{print $1}')
+zone=$(echo $cluster_line | awk '{print $2}')
+gcloud container clusters get-credentials ${cluster_name} --zone ${zone}


### PR DESCRIPTION
So I don't have to manually run the gcloud/kubectl setup commands, for example when [running a local UI with an index from GKE](https://github.com/DataBiosphere/data-explorer-indexers/tree/master/bigquery/deploy#running-a-local-ui-with-an-index-from-gke).