### PR TITLE
Increase put_mapping timeout

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -363,7 +363,11 @@ def index_fields(es, index_name, table, participant_id_column,
 
     field_docs = _field_docs_by_id(id_prefix, '', fields,
                                    participant_id_column, sample_id_column)
-    es.indices.put_mapping(doc_type='type', index=index_name, body=mappings)
+    es.indices.put_mapping(doc_type='type',
+                           index=index_name,
+                           body=mappings,
+                           request_timeout=120)
+
     indexer_util.bulk_index_docs(es, index_name, field_docs)
 
 
@@ -504,7 +508,10 @@ def create_mappings(es, index_name, table_name, fields, participant_id_column,
 
     # Default limit on total number of fields is too small for some datasets.
     es.indices.put_settings({"index.mapping.total_fields.limit": 100000})
-    es.indices.put_mapping(doc_type='type', index=index_name, body=mappings)
+    es.indices.put_mapping(doc_type='type',
+                           index=index_name,
+                           body=mappings,
+                           request_timeout=120)
 
 
 def read_table(bq_client, table_name):


### PR DESCRIPTION
I started seeing this errors. Not sure why; these tables aren't particularly large. Increasing the timeout eliminated these errors.
```
2019080218:14:35    base.py:83 INFO POST http://10.128.15.237:9200/_bulk [status:200 request:0.045s]
2019080218:14:38    base.py:83 INFO PUT http://10.128.15.237:9200/_settings [status:200 request:2.133s]
2019080218:14:41    base.py:83 INFO PUT http://10.128.15.237:9200/_settings [status:200 request:2.948s]
2019080218:14:51    base.py:97 WARNING PUT http://10.128.15.237:9200/baseline_cdr/_mapping/type [status:N/A request:10.013s]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/elasticsearch/connection/http_urllib3.py", line 149, in perform_request
    response = self.pool.urlopen(method, url, body, retries=False, headers=request_headers, **kw)
  File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 638, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/local/lib/python2.7/site-packages/urllib3/util/retry.py", line 343, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 386, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "/usr/local/lib/python2.7/site-packages/urllib3/connectionpool.py", line 306, in _raise_timeout
    raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
ReadTimeoutError: HTTPConnectionPool(host='10.128.15.237', port=9200): Read timed out. (read timeout=10)
```