### PR TITLE
Changes needed for reindexing Baseline internal

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -208,7 +208,7 @@ def _docs_by_id_from_export(storage_client, bucket_name, export_obj_prefix,
         for k in row.keys():
             # A BigQuery FLOAT column can have Infinity. Elasticsearch float
             # doesn't handle Infinity, so discard.
-            if row[k] != 'Infinity':
+            if row[k] != 'Infinity' and row[k] != '-Infinity':
                 row['%s.%s' % (table_name, k)] = row[k]
             del row[k]
         yield participant_id, row

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -203,8 +203,14 @@ def _docs_by_id_from_export(storage_client, bucket_name, export_obj_prefix,
     for row in _rows_from_export(storage_client, bucket_name,
                                  export_obj_prefix):
         participant_id = row[participant_id_column]
+        # Document id is participant id; don't need it as a field.
         del row[participant_id_column]
-        row = {'%s.%s' % (table_name, k): v for k, v in row.iteritems()}
+        for k in row.keys():
+            # A BigQuery FLOAT column can have Infinity. Elasticsearch float
+            # doesn't handle Infinity, so discard.
+            if row[k] != 'Infinity':
+                row['%s.%s' % (table_name, k)] = row[k]
+            del row[k]
         yield participant_id, row
 
 
@@ -503,7 +509,7 @@ def create_mappings(es, index_name, table_name, fields, participant_id_column,
                                   {'type': 'boolean'}, time_series_vals)
 
     # Default limit on total number of fields is too small for some datasets.
-    es.indices.put_settings({"index.mapping.total_fields.limit": 100000})
+    es.indices.put_settings({"index.mapping.total_fields.limit": 1000000})
     es.indices.put_mapping(doc_type='type', index=index_name, body=mappings)
 
 

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -92,7 +92,8 @@ def get_es_client(elasticsearch_url):
     # Retry flags needed for large datasets.
     es = Elasticsearch([elasticsearch_url],
                        retry_on_timeout=True,
-                       max_retries=10)
+                       max_retries=10,
+                       timeout=120)
 
     _wait_elasticsearch_healthy(es)
     return es

--- a/kubernetes-elasticsearch-cluster/es-master-stateful.yaml
+++ b/kubernetes-elasticsearch-cluster/es-master-stateful.yaml
@@ -70,7 +70,7 @@ spec:
         - name: HTTP_ENABLE
           value: "false"
         - name: ES_JAVA_OPTS
-          value: -Xms250m -Xmx250m
+          value: -Xms500m -Xmx500m
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:


### PR DESCRIPTION
FYI @lgolowich 

The field limit problem was hard to debug. For some reason GKE container logs weren't showing the detailed error message. They had:

```
elasticsearch.exceptions.RequestError: TransportError(400, u'illegal_argument_exception', u'[es-master-0][10.60.2.5:9300][indices:admin/mapping/put]')
```

When I ran locally, then I saw the error message:

```
'Limit of total fields [1000] in index [baseline_cdr] has been exceeded'
```

Not sure why error message wasn't in StackDriver logs.