### PR TITLE
Undo some of the changes for Baseline

### DIFF
--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -525,7 +525,7 @@ def create_mappings(es, index_name, table_name, fields, participant_id_column,
                                   {'type': 'boolean'}, time_series_vals)
 
     # Default limit on total number of fields is too small for some datasets.
-    es.indices.put_settings({"index.mapping.total_fields.limit": 1000000})
+    es.indices.put_settings({"index.mapping.total_fields.limit": 100000})
     es.indices.put_mapping(doc_type='type', index=index_name, body=mappings)
 
 

--- a/bigquery/tests/framingham_heart_study_teaching_dataset_fields_golden.json
+++ b/bigquery/tests/framingham_heart_study_teaching_dataset_fields_golden.json
@@ -4,6 +4,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Current cigarette smoking at exam",
       "name": "CURSMOKE"
     },
     "_type": "type"
@@ -13,6 +14,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Casual serum glucose (mg/dL)",
       "name": "GLUCOSE"
     },
     "_type": "type"
@@ -22,6 +24,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days since baseline exam",
       "name": "TIME"
     },
     "_type": "type"
@@ -31,6 +34,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Hospitalized Myocardial Infarction or Fatal Coronary Heart Disease",
       "name": "MI_FCHD"
     },
     "_type": "type"
@@ -40,6 +44,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Angina Pectoris, Myocardial infarction (Hospitalized and silent or unrecognized), Coronary Insufficiency (Unstable Angina), or Fatal Coronary Heart Disease",
       "name": "ANYCHD"
     },
     "_type": "type"
@@ -49,6 +54,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first STROKE event during followup",
       "name": "TIMESTRK"
     },
     "_type": "type"
@@ -58,6 +64,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Serum Total Cholesterol (mg/dL)",
       "name": "TOTCHOL"
     },
     "_type": "type"
@@ -67,6 +74,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Age at exam (years)",
       "name": "AGE"
     },
     "_type": "type"
@@ -76,6 +84,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Diastolic Blood Pressure (mean of last two of three measurements) (mmHg)",
       "name": "DIABP"
     },
     "_type": "type"
@@ -85,6 +94,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Body Mass Index, weight in kilograms/height meters squared",
       "name": "BMI"
     },
     "_type": "type"
@@ -94,6 +104,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Diabetic according to criteria of first exam treated or first exam with casual glucose of 200 mg/dL or more",
       "name": "DIABETES"
     },
     "_type": "type"
@@ -103,6 +114,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Heart rate (Ventricular rate) in beats/min",
       "name": "HEARTRTE"
     },
     "_type": "type"
@@ -112,6 +124,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Prevalent Angina Pectoris at exam",
       "name": "PREVAP"
     },
     "_type": "type"
@@ -121,6 +134,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Prevalent Myocardial Infarction",
       "name": "PREVMI"
     },
     "_type": "type"
@@ -130,6 +144,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Prevalent Stroke",
       "name": "PREVSTRK"
     },
     "_type": "type"
@@ -139,6 +154,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Prevalent Hypertensive. Subject was defined as hypertensive if treated or if second exam at which mean systolic was >=140 mmHg or mean Diastolic >=90 mmHg",
       "name": "PREVHYP"
     },
     "_type": "type"
@@ -148,6 +164,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Low Density Lipoprotein Cholesterol (mg/dL)",
       "name": "LDLC"
     },
     "_type": "type"
@@ -157,6 +174,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first MI_FCHD event during followup",
       "name": "TIMEMIFC"
     },
     "_type": "type"
@@ -166,6 +184,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first CVD event during followup",
       "name": "TIMECVD"
     },
     "_type": "type"
@@ -175,6 +194,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to death if occurring during followup or Number of days from Baseline to censor date. Censor date may be end of followup, or last known contact date if subject is lost to followup",
       "name": "TIMEDTH"
     },
     "_type": "type"
@@ -184,6 +204,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first HYPERTEN event during followup",
       "name": "TIMEHYP"
     },
     "_type": "type"
@@ -193,6 +214,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Participant sex",
       "name": "SEX"
     },
     "_type": "type"
@@ -202,6 +224,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of cigarettes smoked each day",
       "name": "CIGPDAY"
     },
     "_type": "type"
@@ -211,6 +234,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Attained Education",
       "name": "educ"
     },
     "_type": "type"
@@ -220,6 +244,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Examination Cycle",
       "name": "PERIOD"
     },
     "_type": "type"
@@ -229,6 +254,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "High Density Lipoprotein Cholesterol (mg/dL)",
       "name": "HDLC"
     },
     "_type": "type"
@@ -238,6 +264,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Hypertensive. Defined as the first exam treated for high blood pressure or second exam in which either Systolic is >= 140 mmHg or Diastolic >= 90mmHg",
       "name": "HYPERTEN"
     },
     "_type": "type"
@@ -247,6 +274,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first HOSPMI event during followup",
       "name": "TIMEMI"
     },
     "_type": "type"
@@ -256,6 +284,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Prevalent Coronary Heart Disease defined as pre-existing Angina Pectoris, Myocardial Infarction (hospitalized, silent or unrecognized), or Coronary Insufficiency (unstable angina)",
       "name": "PREVCHD"
     },
     "_type": "type"
@@ -265,6 +294,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Angina Pectoris",
       "name": "ANGINA"
     },
     "_type": "type"
@@ -274,6 +304,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first ANYCHD event during followup",
       "name": "TIMECHD"
     },
     "_type": "type"
@@ -283,6 +314,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Systolic Blood Pressure (mean of last two of three measurements) (mmHg)",
       "name": "SYSBP"
     },
     "_type": "type"
@@ -292,6 +324,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Use of Anti-hypertensive medication at exam",
       "name": "BPMEDS"
     },
     "_type": "type"
@@ -301,6 +334,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Death from any cause",
       "name": "DEATH"
     },
     "_type": "type"
@@ -310,6 +344,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Hospitalized Myocardial Infarction",
       "name": "HOSPMI"
     },
     "_type": "type"
@@ -319,6 +354,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Atherothrombotic infarction, Cerebral Embolism, Intracerebral Hemorrhage, or Subarachnoid Hemorrhage or Fatal Cerebrovascular Disease",
       "name": "STROKE"
     },
     "_type": "type"
@@ -328,6 +364,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Myocardial infarction (Hospitalized and silent or unrecognized), Fatal Coronary Heart Disease, Atherothrombotic infarction, Cerebral Embolism, Intracerebral Hemorrhage, or Subarachnoid Hemorrhage or Fatal Cerebrovascular Disease",
       "name": "CVD"
     },
     "_type": "type"
@@ -337,6 +374,7 @@
     "_index": "framingham_heart_study_teaching_dataset_fields",
     "_score": 1,
     "_source": {
+      "description": "Number of days from Baseline exam to first Angina during the followup or Number of days from Baseline to censor date. Censor date may be end of followup, death or last known contact date if subject is lost to followup",
       "name": "TIMEAP"
     },
     "_type": "type"

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash -x
 #
 # Run Data Explorer Indexer integration tests.
 #

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -92,7 +92,8 @@ def get_es_client(elasticsearch_url):
     # Retry flags needed for large datasets.
     es = Elasticsearch([elasticsearch_url],
                        retry_on_timeout=True,
-                       max_retries=10)
+                       max_retries=10,
+                       timeout=30)
 
     _wait_elasticsearch_healthy(es)
     return es

--- a/indexer_util/indexer_util/indexer_util.py
+++ b/indexer_util/indexer_util/indexer_util.py
@@ -92,8 +92,7 @@ def get_es_client(elasticsearch_url):
     # Retry flags needed for large datasets.
     es = Elasticsearch([elasticsearch_url],
                        retry_on_timeout=True,
-                       max_retries=10,
-                       timeout=120)
+                       max_retries=10)
 
     _wait_elasticsearch_healthy(es)
     return es

--- a/kubernetes-elasticsearch-cluster/es-master-stateful.yaml
+++ b/kubernetes-elasticsearch-cluster/es-master-stateful.yaml
@@ -70,7 +70,7 @@ spec:
         - name: HTTP_ENABLE
           value: "false"
         - name: ES_JAVA_OPTS
-          value: -Xms500m -Xmx500m
+          value: -Xms250m -Xmx250m
         - name: PROCESSORS
           valueFrom:
             resourceFieldRef:


### PR DESCRIPTION
Earlier I indexed Baseline with time_series_column=study_day. This turned out to be excessive. There are hundreds if not thousands of fields; each field has ~700 study days. The UI was very slow to load; searches were very slow; after clicking on a bar the update was slow.

I'm not sure we want to support this many subfields.

One advantage of lower timeout is, if things are completely broken, you find out sooner.

Also update Framingham golden file. I changed the first line of the test to `#!/bin/bash -x`. Normally I only add the `-x` for debugging if things are broken, but in this case it's good to always have. Without it, it was [hard to tell what failed](https://circleci.com/gh/DataBiosphere/data-explorer-indexers/887).