### PR TITLE
Support 'columns_to_ignore', an optional list of BigQuery column name…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             # Needed to create samples file
             echo '{"project_id": "ci-test-data-explorer"}' > dataset_config/1000_genomes/deploy.json
             echo '{"project_id": "ci-test-data-explorer"}' > dataset_config/framingham_heart_study_teaching/deploy.json
-            echo '{"project_id": "ci-test-data-explorer"}' > tests/columns_to_ignore_test/deploy.json
+            echo '{"project_id": "ci-test-data-explorer"}' > bigquery/tests/columns_to_ignore_test/deploy.json
             echo ${GOOGLE_SERVICE_KEY} | base64 --decode > ${HOME}/.config/gcloud/application_default_credentials.json
             cd bigquery && tests/integration.sh ${GOOGLE_PROJECT_ID}
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
             # Needed to create samples file
             echo '{"project_id": "ci-test-data-explorer"}' > dataset_config/1000_genomes/deploy.json
             echo '{"project_id": "ci-test-data-explorer"}' > dataset_config/framingham_heart_study_teaching/deploy.json
+            echo '{"project_id": "ci-test-data-explorer"}' > tests/columns_to_ignore_test/deploy.json
             echo ${GOOGLE_SERVICE_KEY} | base64 --decode > ${HOME}/.config/gcloud/application_default_credentials.json
             cd bigquery && tests/integration.sh ${GOOGLE_PROJECT_ID}
       - save_cache:

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -390,7 +390,8 @@ def index_fields(es, index_name, table, participant_id_column,
     }
 
     field_docs = _field_docs_by_id(id_prefix, '', fields,
-                                   participant_id_column, sample_id_column, columns_to_ignore)
+                                   participant_id_column, sample_id_column,
+                                   columns_to_ignore)
     es.indices.put_mapping(doc_type='type', index=index_name, body=mappings)
     indexer_util.bulk_index_docs(es, index_name, field_docs)
 

--- a/bigquery/indexer.py
+++ b/bigquery/indexer.py
@@ -113,12 +113,13 @@ def _table_name_from_table(table):
 
 
 def _field_docs_by_id(id_prefix, name_prefix, fields, participant_id_column,
-                      sample_id_column):
+                      sample_id_column, columns_to_ignore):
     # This method is recursive to handle nested fields (BigQuery RECORD columns).
     # For nested fields, field name includes all levels of nesting, eg "addresses.city".
     for field in fields:
         if (field.name == participant_id_column
-                or field.name == sample_id_column):
+                or field.name == sample_id_column
+                or field.name in columns_to_ignore):
             continue
         field_name = field.name
         field_id = field.name
@@ -133,7 +134,8 @@ def _field_docs_by_id(id_prefix, name_prefix, fields, participant_id_column,
             for field_doc in _field_docs_by_id(field_id, field_name,
                                                field.fields,
                                                participant_id_column,
-                                               sample_id_column):
+                                               sample_id_column,
+                                               columns_to_ignore):
                 yield field_doc
         else:
             field_dict = {'name': field_name}
@@ -346,7 +348,7 @@ def index_table(es, bq_client, storage_client, index_name, table,
 
 
 def index_fields(es, index_name, table, participant_id_column,
-                 sample_id_column):
+                 sample_id_column, columns_to_ignore):
     table_name = _table_name_from_table(table)
     logger.info('Indexing %s into %s.' % (table_name, index_name))
 
@@ -388,7 +390,7 @@ def index_fields(es, index_name, table, participant_id_column,
     }
 
     field_docs = _field_docs_by_id(id_prefix, '', fields,
-                                   participant_id_column, sample_id_column)
+                                   participant_id_column, sample_id_column, columns_to_ignore)
     es.indices.put_mapping(doc_type='type', index=index_name, body=mappings)
     indexer_util.bulk_index_docs(es, index_name, field_docs)
 
@@ -618,6 +620,7 @@ def main():
     sample_id_column = bigquery_config.get('sample_id_column', None)
     sample_file_columns = bigquery_config.get('sample_file_columns', {})
     time_series_column = bigquery_config.get('time_series_column', None)
+    columns_to_ignore = bigquery_config.get('columns_to_ignore', [])
     bq_client = bigquery.Client(project=deploy_project_id)
     storage_client = storage.Client(project=deploy_project_id)
 
@@ -626,7 +629,7 @@ def main():
         time_series_vals = get_time_series_vals(bq_client, time_series_column,
                                                 table_name, table)
         index_fields(es, fields_index_name, table, participant_id_column,
-                     sample_id_column)
+                     sample_id_column, columns_to_ignore)
         create_mappings(es, index_name, table_name, table.schema,
                         participant_id_column, sample_id_column,
                         sample_file_columns, time_series_column,

--- a/bigquery/tests/columns_to_ignore_test/README.md
+++ b/bigquery/tests/columns_to_ignore_test/README.md
@@ -1,0 +1,6 @@
+The public [1000 Genomes](http://www.internationalgenome.org/about) dataset.
+
+For a live Data Explorer of this dataset, see https://test-data-explorer.appspot.com
+
+See [here](https://github.com/DataBiosphere/data-explorer/blob/master/dataset_config/1000_genomes/ui.json)
+for Data Explorer UI configuration.

--- a/bigquery/tests/columns_to_ignore_test/README.md
+++ b/bigquery/tests/columns_to_ignore_test/README.md
@@ -1,6 +1,2 @@
-The public [1000 Genomes](http://www.internationalgenome.org/about) dataset.
-
-For a live Data Explorer of this dataset, see https://test-data-explorer.appspot.com
-
-See [here](https://github.com/DataBiosphere/data-explorer/blob/master/dataset_config/1000_genomes/ui.json)
-for Data Explorer UI configuration.
+These json files are used in the integration tests in integration.sh for test_columns_to_ignore.
+These files configure a dataset like 1000 genomes, but with certain columns ignored.

--- a/bigquery/tests/columns_to_ignore_test/bigquery.json
+++ b/bigquery/tests/columns_to_ignore_test/bigquery.json
@@ -43,5 +43,8 @@
     },
     "time_series_column": "",
     "time_series_unit": "",
-    "columns_to_ignore": []
+    "columns_to_ignore": [
+        "chr_3_vcf",
+        "chr_4_vcf"
+    ]
 }

--- a/bigquery/tests/columns_to_ignore_test/bigquery.json
+++ b/bigquery/tests/columns_to_ignore_test/bigquery.json
@@ -22,8 +22,8 @@
 //   Unit of time_series_column. If time_series_column is set, this
 //   must be set. Examples: Month, Year.
 // columns_to_ignore:
-//   An (optional) list of BigQuery column names that will not 
-//   appear in the search bar.Just the column names, 
+//   An (optional) list of BigQuery column names that will not be indexed.
+//   These columns won't appear in search results.
 {
     "table_names":[
         "verily-public-data.human_genome_variants.1000_genomes_participant_info",

--- a/bigquery/tests/columns_to_ignore_test/dataset.json
+++ b/bigquery/tests/columns_to_ignore_test/dataset.json
@@ -1,0 +1,11 @@
+// name:
+//   Dataset name. This name will be displayed in the Data Explorer UI. Also,
+//   the Elasticsearch index will be given this name.
+// authorization_domain:
+//   FireCloud Authorization Domain. This must be set for access-controlled
+//   datasets. This is used to restrict which Terra workspaces data can be
+//   sent to. See https://gatkforums.broadinstitute.org/firecloud/discussion/9524/authorization-domains
+{
+  "name": "1000 Genomes test columns to ignore",
+  "authorization_domain": ""
+}

--- a/bigquery/tests/columns_to_ignore_test/deploy.json
+++ b/bigquery/tests/columns_to_ignore_test/deploy.json
@@ -1,3 +1,0 @@
-{
-  "project_id": "test-data-explorer"
-}

--- a/bigquery/tests/columns_to_ignore_test/deploy.json
+++ b/bigquery/tests/columns_to_ignore_test/deploy.json
@@ -1,0 +1,3 @@
+{
+  "project_id": "test-data-explorer"
+}

--- a/bigquery/tests/integration.sh
+++ b/bigquery/tests/integration.sh
@@ -22,7 +22,8 @@
 set -o errexit
 set -o nounset
 
-waitForClusterHealthy() {
+
+function wait_for_cluster_healthy() {
   status=''
   # For some reason, cluster health is green on CircleCI
   while [[ $status != 'yellow' && $status != 'green' ]]; do
@@ -32,87 +33,152 @@ waitForClusterHealthy() {
   done
   echo "Elasticsearch cluster is now healthy"
 }
+readonly -f wait_for_cluster_healthy
 
 
-docker network create data-explorer_default
+function delete_indexes() {
+  curl -XDELETE localhost:9200/1000_genomes
+  curl -XDELETE localhost:9200/1000_genomes_fields
+  curl -XDELETE localhost:9200/framingham_heart_study_teaching_dataset
+  curl -XDELETE localhost:9200/framingham_heart_study_teaching_dataset_fields
+  curl -XDELETE localhost:9200/columns_to_ignore_test
+  curl -XDELETE localhost:9200/columns_to_ignore_test_fields
+}
+readonly -f delete_indexes
 
-# Run Elasticsearch in the background with the indexer in the foreground to prevent blocking the main thread.
-docker-compose up -d elasticsearch
-waitForClusterHealthy
-curl -XDELETE localhost:9200/1000_genomes
-curl -XDELETE localhost:9200/1000_genomes_fields
-curl -XDELETE localhost:9200/framingham_heart_study_teaching_dataset
-curl -XDELETE localhost:9200/framingham_heart_study_teaching_dataset_fields
 
-docker-compose up --build indexer
-DATASET_CONFIG_DIR=dataset_config/framingham_heart_study_teaching docker-compose up --build indexer
-# For some reason index isn't available right after indexer terminates, so sleep.
-sleep 5
+function set_up_es() {
+  docker network inspect data-explorer_default >/dev/null 2>&1 || \
+    docker network create data-explorer_default
 
-# Validate the correct number of documents were indexed.
-DOC_COUNT_GENOMES=$(curl -s 'http://localhost:9200/1000_genomes/_search' | jq -r '.hits.total')
-if [ "$DOC_COUNT_GENOMES" != "3500" ]; then
-  echo "Number of documents is incorrect, expected 3500, got $DOC_COUNT_GENOMES"
-  exit 1
-fi
+  # Run Elasticsearch in the background with the indexer in the foreground to prevent blocking the main thread.
+  docker-compose up -d elasticsearch
+  wait_for_cluster_healthy
+  delete_indexes
+}
+readonly -f set_up_es
 
-DOC_COUNT_FRAMINGHAM=$(curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset/_search' | jq -r '.hits.total')
-if [ "$DOC_COUNT_FRAMINGHAM" != "4434" ]; then
-  echo "Number of documents is incorrect, expected 4434, got $DOC_COUNT_FRAMINGHAM"
-  exit 1
-fi
 
-# Write the indexes out to a file in order to diff.
-curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'tests/1000_genomes.json'
-DIFF=$(diff tests/1000_genomes_golden.json tests/1000_genomes.json)
-if [ "$DIFF" != "" ]; then
-  echo "Index does not match golden json file, diff:"
-  echo "$DIFF"
-  exit 1
-fi
+function set_up_indexes(){
+  docker-compose up --build indexer
+  DATASET_CONFIG_DIR=dataset_config/framingham_heart_study_teaching docker-compose up --build indexer
+  # For some reason index isn't available right after indexer terminates, so sleep.
+  sleep 5
+}
+readonly -f set_up_indexes
 
-curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset/type/9334261' | jq -rS '._source' > 'tests/framingham_heart_study_teaching_dataset.json'
-DIFF=$(diff tests/framingham_heart_study_teaching_dataset_golden.json tests/framingham_heart_study_teaching_dataset.json)
-if [ "$DIFF" != "" ]; then
-  echo "Index does not match golden json file, diff:"
-  echo "$DIFF"
-  exit 1
-fi
 
-# Write the mappings out to files in order to diff.
-curl -s 'http://localhost:9200/1000_genomes/_mappings' | jq -rS '.' > 'tests/1000_genomes_mappings.json'
-DIFF=$(diff tests/1000_genomes_mappings_golden.json tests/1000_genomes_mappings.json)
-if [ "$DIFF" != "" ]; then
-  echo "Mappings do not match golden json file, diff:"
-  echo "$DIFF"
-  exit 1
-fi
+function validate_framingham_heart_study_teaching_dataset() {
+  # Validate the correct number of documents were indexed.
+  DOC_COUNT_FRAMINGHAM=$(curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset/_search' | jq -r '.hits.total')
+  if [ "$DOC_COUNT_FRAMINGHAM" != "4434" ]; then
+    echo "Number of documents is incorrect, expected 4434, got $DOC_COUNT_FRAMINGHAM"
+    exit 1
+  fi
 
-curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset/_mappings?pretty' | jq -rS '.' > 'tests/framingham_heart_study_teaching_dataset_mappings.json'
-DIFF=$(diff tests/framingham_heart_study_teaching_dataset_mappings_golden.json tests/framingham_heart_study_teaching_dataset_mappings.json)
-if [ "$DIFF" != "" ]; then
-  echo "Mappings do not match golden json file, diff:"
-  echo "$DIFF"
-  exit 1
-fi
+  # Write the indexes out to a file in order to diff.
+  curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset/type/9334261' | jq -rS '._source' > 'tests/framingham_heart_study_teaching_dataset.json'
+  DIFF=$(diff tests/framingham_heart_study_teaching_dataset_golden.json tests/framingham_heart_study_teaching_dataset.json)
+  if [ "$DIFF" != "" ]; then
+    echo "Index does not match golden json file, diff:"
+    echo "$DIFF"
+    exit 1
+  fi
 
-# Write the fields indexes out to files in order to diff.
-curl -s 'http://localhost:9200/1000_genomes_fields/_search?size=200' | jq -rS '.hits.hits' > 'tests/1000_genomes_fields.json'
-DIFF=$(diff tests/1000_genomes_fields_golden.json tests/1000_genomes_fields.json)
-if [ "$DIFF" != "" ]; then
-  echo "Fields index does not match golden json file, diff:"
-  echo "$DIFF"
-  exit 1
-fi
+  # Write the mappings out to files in order to diff.
+  curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset/_mappings?pretty' | jq -rS '.' > 'tests/framingham_heart_study_teaching_dataset_mappings.json'
+  DIFF=$(diff tests/framingham_heart_study_teaching_dataset_mappings_golden.json tests/framingham_heart_study_teaching_dataset_mappings.json)
+  if [ "$DIFF" != "" ]; then
+    echo "Mappings do not match golden json file, diff:"
+    echo "$DIFF"
+    exit 1
+  fi
 
-curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset_fields/_search?size=200' | jq -rS '.hits.hits' > 'tests/framingham_heart_study_teaching_dataset_fields.json'
-DIFF=$(diff tests/framingham_heart_study_teaching_dataset_fields_golden.json tests/framingham_heart_study_teaching_dataset_fields.json)
-if [ "$DIFF" != "" ]; then
-  echo "Fields index does not match golden json file, diff:"
-  echo "$DIFF"
-  exit 1
-fi
+  # Write the fields indexes out to files in order to diff.
+  curl -s 'http://localhost:9200/framingham_heart_study_teaching_dataset_fields/_search?size=200' | jq -rS '.hits.hits' > 'tests/framingham_heart_study_teaching_dataset_fields.json'
+  DIFF=$(diff tests/framingham_heart_study_teaching_dataset_fields_golden.json tests/framingham_heart_study_teaching_dataset_fields.json)
+  if [ "$DIFF" != "" ]; then
+    echo "Fields index does not match golden json file, diff:"
+    echo "$DIFF"
+    exit 1
+  fi
+}
+readonly -f validate_framingham_heart_study_teaching_dataset
 
+
+function validate_1000_genomes() {
+  # Validate the correct number of documents were indexed.
+  DOC_COUNT_GENOMES=$(curl -s 'http://localhost:9200/1000_genomes/_search' | jq -r '.hits.total')
+  if [ "$DOC_COUNT_GENOMES" != "3500" ]; then
+    echo "Number of documents is incorrect, expected 3500, got $DOC_COUNT_GENOMES"
+    exit 1
+  fi
+
+  # Write the indexes out to a file in order to diff.
+  curl -s 'http://localhost:9200/1000_genomes/type/HG02924' | jq -rS '._source' > 'tests/1000_genomes.json'
+  DIFF=$(diff tests/1000_genomes_golden.json tests/1000_genomes.json)
+  if [ "$DIFF" != "" ]; then
+    echo "Index does not match golden json file, diff:"
+    echo "$DIFF"
+    exit 1
+  fi
+
+  # Write the mappings out to files in order to diff.
+  curl -s 'http://localhost:9200/1000_genomes/_mappings' | jq -rS '.' > 'tests/1000_genomes_mappings.json'
+  DIFF=$(diff tests/1000_genomes_mappings_golden.json tests/1000_genomes_mappings.json)
+  if [ "$DIFF" != "" ]; then
+    echo "Mappings do not match golden json file, diff:"
+    echo "$DIFF"
+    exit 1
+  fi
+
+  # Write the fields indexes out to files in order to diff.
+  curl -s 'http://localhost:9200/1000_genomes_fields/_search?size=200' | jq -rS '.hits.hits' > 'tests/1000_genomes_fields.json'
+  DIFF=$(diff tests/1000_genomes_fields_golden.json tests/1000_genomes_fields.json)
+  if [ "$DIFF" != "" ]; then
+    echo "Fields index does not match golden json file, diff:"
+    echo "$DIFF"
+    exit 1
+  fi
+}
+readonly -f validate_1000_genomes
+
+
+function test_columns_to_ignore() {
+  # Index a dataset that has columns named chr_1_vcf, chr_2_vcf, etc
+  # In the config files, explicitly mark that chr_3_vcf as ignored
+  # Search should match for chr_1_vcf, but not chr_3_vcf
+  echo "Running test_columns_to_ignore"
+
+  DATASET_CONFIG_DIR=tests/columns_to_ignore_test docker-compose up --build indexer
+
+  sleep 5
+
+  es_id_in_index='samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_1_vcf'
+  FOUND=$(curl -s "localhost:9200/1000_genomes_test_columns_to_ignore_fields/type/${es_id_in_index}" | jq -rS '.found')
+  if [ "$FOUND" == "false" ]; then
+    echo "${es_id_in_index} was not found in fields when it should have been."
+    exit 1
+  fi
+
+  es_id_not_in_index='samples.verily-public-data.human_genome_variants.1000_genomes_sample_info.chr_3_vcf'
+  FOUND=$(curl -s "localhost:9200/1000_genomes_test_columns_to_ignore_fields/type/${es_id_not_in_index}" | jq -rS '.found')
+  if [ "$FOUND" == "true" ]; then
+    echo "${es_id_not_in_index} was found in fields when it should NOT have been."
+    exit 1
+  fi
+}
+readonly -f test_columns_to_ignore
+
+# Run integration tests that validate that the base 1000 genomes
+# and framingham heart study data explorers still work
+set_up_es
+set_up_indexes
+validate_1000_genomes
+validate_framingham_heart_study_teaching_dataset
+
+# Run integration test that checks the "columns_to_ignore" feature
+test_columns_to_ignore
 
 rm tests/1000_genomes.json
 rm tests/1000_genomes_mappings.json

--- a/dataset_config/1000_genomes/bigquery.json
+++ b/dataset_config/1000_genomes/bigquery.json
@@ -22,8 +22,8 @@
 //   Unit of time_series_column. If time_series_column is set, this
 //   must be set. Examples: Month, Year.
 // columns_to_ignore:
-//   An (optional) list of BigQuery column names that will not 
-//   appear in the search bar.Just the column names, 
+//   An (optional) list of BigQuery column names that will not be indexed.
+//   These columns won't appear in search results.
 {
     "table_names":[
         "verily-public-data.human_genome_variants.1000_genomes_participant_info",

--- a/dataset_config/framingham_heart_study_teaching/bigquery.json
+++ b/dataset_config/framingham_heart_study_teaching/bigquery.json
@@ -21,6 +21,9 @@
 // time_series_unit:
 //   Unit of time_series_column. If time_series_column is set, this
 //   must be set. Examples: Month, Year.
+// columns_to_ignore:
+//   An (optional) list of BigQuery column names that will not 
+//   appear in the search bar.Just the column names, 
 {
   "table_names": [
     "verily-public-data.framingham_heart_study_teaching.framingham_heart_study_teaching"
@@ -29,5 +32,6 @@
   "sample_id_column": "",
   "sample_file_columns": {},
   "time_series_column": "PERIOD",
-  "time_series_unit": "Period"
+  "time_series_unit": "Period",
+  "columns_to_ignore": []
 }

--- a/dataset_config/framingham_heart_study_teaching/bigquery.json
+++ b/dataset_config/framingham_heart_study_teaching/bigquery.json
@@ -22,8 +22,8 @@
 //   Unit of time_series_column. If time_series_column is set, this
 //   must be set. Examples: Month, Year.
 // columns_to_ignore:
-//   An (optional) list of BigQuery column names that will not 
-//   appear in the search bar.Just the column names, 
+//   An (optional) list of BigQuery column names that will not be indexed.
+//   These columns won't appear in search results.
 {
   "table_names": [
     "verily-public-data.framingham_heart_study_teaching.framingham_heart_study_teaching"

--- a/dataset_config/template/bigquery.json
+++ b/dataset_config/template/bigquery.json
@@ -21,6 +21,9 @@
 // time_series_unit:
 //   Unit of time_series_column. If time_series_column is set, this
 //   must be set. Examples: Month, Year.
+// columns_to_ignore:
+//   An (optional) list of BigQuery column names that will not 
+//   appear in the search bar.Just the column names, 
 {
   "table_names": [],
 
@@ -29,5 +32,6 @@
 
   "sample_file_columns": {},
   "time_series_column": "",
-  "time_series_unit": ""
+  "time_series_unit": "",
+  "columns_to_ignore": []
 }

--- a/dataset_config/template/bigquery.json
+++ b/dataset_config/template/bigquery.json
@@ -22,8 +22,8 @@
 //   Unit of time_series_column. If time_series_column is set, this
 //   must be set. Examples: Month, Year.
 // columns_to_ignore:
-//   An (optional) list of BigQuery column names that will not 
-//   appear in the search bar.Just the column names, 
+//   An (optional) list of BigQuery column names that will not be indexed.
+//   These columns won't appear in search results.
 {
   "table_names": [],
 


### PR DESCRIPTION
…s that will not appear in the search bar

Updated integration.sh to include an e2e test for this feature. I refactored the code a bit, but the new test is in the function `test_columns_to_ignore`. It indexes 1000 genomes, but includes columns in the `columns_to_ignore` option. It then checks that the ignored column is not found in the fields index.